### PR TITLE
[Feat] #91 - 오류 및 확인 알림을 위한 ToasterPopupViewController 에 로직 추가

### DIFF
--- a/TOASTER-iOS/Global/Extensions/UIViewController+.swift
+++ b/TOASTER-iOS/Global/Extensions/UIViewController+.swift
@@ -50,6 +50,21 @@ extension UIViewController {
         present(popupViewController, animated: false)
     }
     
+    /// 팝업 표출할 수 있도록 하는 메서드
+    func showConfirmationPopup(forMainText: String? = nil,
+                               forSubText: String? = nil,
+                               centerButtonTitle: String,
+                               centerButtonHandler: (() -> Void)? = nil) {
+        
+        let popupViewController = ToasterPopupViewController(mainText: forMainText,
+                                                             subText: forSubText,
+                                                             centerButtonTitle: centerButtonTitle,
+                                                             centerButtonHandler: centerButtonHandler)
+        
+        popupViewController.modalPresentationStyle = .overFullScreen
+        present(popupViewController, animated: false)
+    }
+    
     /// 토스트 메시지를 보여주는 메서드
     func showToastMessage(width: CGFloat, 
                           status: ToastStatus,

--- a/TOASTER-iOS/Present/Setting/SettingViewController.swift
+++ b/TOASTER-iOS/Present/Setting/SettingViewController.swift
@@ -168,11 +168,13 @@ private extension SettingViewController {
                 let result = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
                 
                 if result.access && result.refresh {
-                    self?.changeViewController(viewController: LoginViewController())
+                    self?.showConfirmationPopup(forMainText: "로그아웃", forSubText: "로그아웃이 완료되었습니다", centerButtonTitle: "확인", centerButtonHandler: self?.popupConfirmationButtonTapped)
                 }
             case .notFound, .networkFail:
                 print("🍞⛔️로그아웃 실패⛔️🍞")
+                self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 로그아웃이 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
             default:
+                self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 로그아웃이 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
                 print("🍞⛔️로그아웃 실패⛔️🍞")
             }
         }
@@ -185,14 +187,20 @@ private extension SettingViewController {
                 let result = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
                 
                 if result.access && result.refresh {
-                    self?.changeViewController(viewController: LoginViewController())
+                    self?.showConfirmationPopup(forMainText: "회원탈퇴", forSubText: "회원탈퇴가 완료되었습니다", centerButtonTitle: "확인", centerButtonHandler: self?.popupConfirmationButtonTapped)
                 }
             case .notFound, .unProcessable, .networkFail:
                 print("🍞⛔️회원탈퇴 실패⛔️🍞")
+                self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 회원탈퇴가 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
             default:
                 print("🍞⛔️회원탈퇴 실패⛔️🍞")
+                self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 회원탈퇴가 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
             }
         }
+    }
+    
+    func popupConfirmationButtonTapped() {
+        self.changeViewController(viewController: LoginViewController())
     }
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #91 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/f912ff28-8c8f-413c-b4ca-fa40de2a0684" width ="180"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/6f0f7c8c-09a2-4858-ad70-f64985be7620" width ="180"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/19069756-4478-4fd4-a45d-423e91138324" width ="180"> |

## 🖥️ 주요 코드 설명

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->

`ToasterPopup 사용방법`
- VC 가 위치한 곳에서 다음과 같이 showConfirmationPopup 메서드를 작성해주시면 됩니다.
```swift
self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 로그아웃이 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
```

`ToasterPopupViewController`
- 좌, 우 버튼이 존재하는 Cancelable, 가운데 버튼이 존재하는 Confirmation case 를 갖고 있는 ToasterPopupType 을 구현
- ToasterPopupType 에 맞게 구현하기 위한 init 추가
- ToasterPopupType 에 따른 AutoLayout 구현
```swift
enum ToasterPopupType {
    case Confirmation // 가운테 버튼 존재
    case Cancelable // 좌,우 버튼 존재
}

final class ToasterPopupViewController: UIViewController {
    //...

    /// 확인 ( 에러 ) 을 위한 Popup init
    init(mainText: String?,
         subText: String?,
         centerButtonTitle: String,
         centerButtonHandler: ButtonAction?) {
        
        self.mainText = mainText
        self.subText = subText
        self.leftButtonTitle = ""
        self.rightButtonTitle = ""
        self.centerButtonTitle = centerButtonTitle
        self.leftButtonHandler = nil
        self.rightButtonHandler = nil
        self.centerButtonHandler = centerButtonHandler
        
        if centerButtonTitle.isEmpty {
            self.popupType = .Cancelable
        } else {
            self.popupType = .Confirmation
        }
    
        super.init(nibName: nil, bundle: nil)
    }

    //...

    @objc func centerButtonTapped() {
        if let action = centerButtonHandler {
            action()
        } else {
            cancleAction()
        }
    }
}
```

`SettingViewController`
- 로그아웃이 성공& 실패 시 보여줄 showConfirmationPopup 을 호출합니다.
```swift
func fetchSignOut() {
    NetworkService.shared.authService.postLogout { [weak self] result in
        switch result {
        case .success:
            let result = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
            
            if result.access && result.refresh {
                self?.showConfirmationPopup(forMainText: "로그아웃", forSubText: "로그아웃이 완료되었습니다", centerButtonTitle: "확인", centerButtonHandler: self?.popupConfirmationButtonTapped)
            }
        case .notFound, .networkFail:
            print("🍞⛔️로그아웃 실패⛔️🍞")
            self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 로그아웃이 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
        default:
            self?.showConfirmationPopup(forMainText: "네트워크 연결 오류", forSubText: "네트워크 오류로 로그아웃이 실패하였습니다", centerButtonTitle: "확인", centerButtonHandler: nil)
            print("🍞⛔️로그아웃 실패⛔️🍞")
        }
    }
}
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
