### PR TITLE
[Feat] #105 - 링크 임베드 접근 권한 및 외부 웹뷰 에러 해결 

### DIFF
--- a/TOASTER-iOS/Application/SceneDelegate.swift
+++ b/TOASTER-iOS/Application/SceneDelegate.swift
@@ -50,6 +50,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        if UIPasteboard.general.string != nil {
+            if let rootViewController = window?.rootViewController as? ToasterNavigationController {
+                let addLinkViewController = AddLinkViewController()
+                rootViewController.pushViewController(addLinkViewController, animated: true)
+                addLinkViewController.embedURL(url: UIPasteboard.general.string ?? "")
+            }
+        }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/TOASTER-iOS/Present/AddLink/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/AddLinkViewController.swift
@@ -80,6 +80,12 @@ extension AddLinkViewController {
     func setupDelegate(forDelegate: AddLinkViewControllerPopDelegate) {
         delegate = forDelegate
     }
+    
+    // 클립보드 붙여넣기 Alert -> 붙여넣기 허용 클릭 후 자동 링크 임베드를 위한 함수
+    func embedURL(url: String) {
+        addLinkView.linkEmbedTextField.becomeFirstResponder()
+        addLinkView.linkEmbedTextField.text = url
+    }
 }
 
 // MARK: - Private extension

--- a/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
+++ b/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
@@ -156,11 +156,9 @@ extension AddLinkView: UITextFieldDelegate {
         // 텍스트 필드에 입력이 시작될 때 호출되는 메서드
         nextTopButton.backgroundColor = .black850
         linkEmbedTextField.placeholder = nil
-        // 여기서 타이머를 시작하고, 1.5초 후에 텍스트를 확인하고 테두리 색상을 변경합니다.
+        // 여기서 타이머를 시작하고, 0.5초 후에 텍스트를 확인 후 텍스트필드 에러 처리
         if textField.text?.count ?? 0 > 1 {
             startTimer()
-        } else {
-            // 버튼 클릭시 링크를 입력해주세요 에러
         }
     }
     
@@ -172,15 +170,13 @@ extension AddLinkView: UITextFieldDelegate {
     }
     
     func startTimer() {
-        // 1.5초 후에 checkTextField 메서드 호출
+        // 0.5초 후에 checkTextField 메서드 호출
         timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
             // URL 유효 여부 판단 후 처리
             if let urlText = self?.linkEmbedTextField.text {
-                if urlText.contains("http") {
-                    print("유효한 링크입니다. :", urlText)
+                if urlText.prefix(4) == "http" {
                     self?.resetError()
                 } else {
-                    print("유효하지 않은 링크입니다. :", urlText)
                     self?.isValidLinkError()
                 }
             }
@@ -197,21 +193,6 @@ extension AddLinkView: UITextFieldDelegate {
         // 타이머를 정지, 테두리 초기화
         timer?.invalidate()
         linkEmbedTextField.layer.borderColor = UIColor.clear.cgColor
-    }
-    
-    // MARK: - URL 유효성 검사
-    
-    // 화면 구현 완성하고 검사할게요
-    func isValidURL(_ urlString: String?) -> Bool {
-        guard let urlString = urlString else {
-            return false
-        }
-        // 정규표현식을 사용하여 URL 패턴 확인
-        let urlPattern = #"^(https?|ftp):\/\/[^\s\/$.?#].[^\s]*$"# // 간단한 URL 패턴
-        let regex = try? NSRegularExpression(pattern: urlPattern, options: .caseInsensitive)
-        let range = NSRange(location: 0, length: urlString.utf16.count)
-        
-        return regex?.firstMatch(in: urlString, options: [], range: range) != nil
     }
     
     // MARK: - Text Field Error

--- a/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
+++ b/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
@@ -174,7 +174,7 @@ extension AddLinkView: UITextFieldDelegate {
         timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
             // URL 유효 여부 판단 후 처리
             if let urlText = self?.linkEmbedTextField.text {
-                if urlText.prefix(4) == "http" {
+                if (urlText.prefix(8) == "https://") || (urlText.prefix(7) == "http://") {
                     self?.resetError()
                 } else {
                     self?.isValidLinkError()

--- a/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
@@ -59,7 +59,7 @@ extension MainCollectionViewCell {
         countToastLabel.text = String(forModel.readToastNum) + " / " + String(forModel.allToastNum)
         countToastLabel.asFontColor(targetString: String(forModel.readToastNum), font: .suitBold(size: 20), color: .toasterPrimary)
         
-        linkProgressView.progress = Float(forModel.readToastNum)/Float(forModel.allToastNum)
+        linkProgressView.setProgress(Float(forModel.readToastNum)/Float(forModel.allToastNum), animated: true)
     }
 }
 
@@ -104,8 +104,9 @@ private extension MainCollectionViewCell {
         linkProgressView.do {
             $0.trackTintColor = .gray100
             $0.progressTintColor = .toasterPrimary
-            $0.makeRounded(radius: 8)
+            $0.makeRounded(radius: 6)
             $0.clipsToBounds = true
+            $0.subviews[1].makeRounded(radius: 6)
         }
     }
     

--- a/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
+++ b/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
@@ -60,6 +60,18 @@ final class LinkWebViewController: UIViewController {
         setupNavigationBarAction()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        hideNavigationBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        showNavigationBar()
+    }
+    
     deinit {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
     }
@@ -94,7 +106,6 @@ private extension LinkWebViewController {
     func setupStyle() {
         view.bringSubviewToFront(progressView)
         view.backgroundColor = .toasterWhite
-        hideNavigationBar()
         
         progressView.do {
             $0.tintColor = .toasterPrimary


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #105 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
![Simulator Screen Recording - iPhone 15 Pro - 2024-01-18 at 07 20 17](https://github.com/Link-MIND/TOASTER-iOS/assets/101050833/766f2821-a2a8-4147-87b8-44741d0b6642)


## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`SceneDelegate`
- 클립보드에 문자가 있고 [붙여넣기 허용]을 클릭하면 링크 임베드 화면으로 넘어갑니다. 
- 클립보드에 있던 문자열을 `embedURL`이라는 함수를 통해 `linkEmbedTextField`에 자동 임베드가 되도록 합니다. 

```swift
func sceneWillEnterForeground(_ scene: UIScene) {
        if UIPasteboard.general.string != nil {
            if let rootViewController = window?.rootViewController as? ToasterNavigationController {
                let addLinkViewController = AddLinkViewController()
                rootViewController.pushViewController(addLinkViewController, animated: true)
                addLinkViewController.embedURL(url: UIPasteboard.general.string ?? "")
            }
        }
    }
```

`AddLinkViewController`
- 자동 임베드를 위한 `embedURL` 함수
```swift
// 클립보드 붙여넣기 Alert -> 붙여넣기 허용 클릭 후 자동 링크 임베드를 위한 함수
func embedURL(url: String) {
    addLinkView.linkEmbedTextField.becomeFirstResponder()
    addLinkView.linkEmbedTextField.text = url
}
```


`LinkWebViewController`
- 외부 웹뷰 이동 후 앱으로 복귀하면 NavigationBar가 사라지는 이슈 해결
```swift
override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        
        hideNavigationBar()
    }
    
override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    
    showNavigationBar()
}
```


## 📂 참고한 내용
<!-- 참고한 사이트나 정보가 있다면 작성주세요 -->
- 멋진 아요 리드 다예님의 개발 능력 

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
