### PR TITLE
[Fix] #120 - 회원탈퇴 Alert UI 수정

### DIFF
--- a/TOASTER-iOS/Present/Setting/SettingViewController.swift
+++ b/TOASTER-iOS/Present/Setting/SettingViewController.swift
@@ -188,7 +188,7 @@ private extension SettingViewController {
                 let result = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
                 
                 if result.access && result.refresh {
-                    self?.showPopup(forMainText: "정말로 탈퇴하시겠어요?", forSubText: "회원 탈퇴 시 지금까지 저장한 모든 링크가 사라져요.", forLeftButtonTitle: "네, 탈퇴할래요", forRightButtonTitle: "더 써볼래요", forLeftButtonHandler: self?.popupConfirmationButtonTapped, forRightButtonHandler: nil)
+                    self?.showPopup(forMainText: "정말로 탈퇴하시겠어요?", forSubText: "회원 탈퇴 시 지금까지\n저장한 모든 링크가 사라져요.", forLeftButtonTitle: "네, 탈퇴할래요", forRightButtonTitle: "더 써볼래요", forLeftButtonHandler: self?.popupConfirmationButtonTapped, forRightButtonHandler: nil)
                 }
             case .notFound, .unProcessable, .networkFail:
                 print("🍞⛔️회원탈퇴 실패⛔️🍞")

--- a/TOASTER-iOS/Present/Setting/SettingViewController.swift
+++ b/TOASTER-iOS/Present/Setting/SettingViewController.swift
@@ -188,7 +188,7 @@ private extension SettingViewController {
                 let result = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
                 
                 if result.access && result.refresh {
-                    self?.showConfirmationPopup(forMainText: "회원탈퇴", forSubText: "회원탈퇴가 완료되었습니다", centerButtonTitle: "확인", centerButtonHandler: self?.popupConfirmationButtonTapped)
+                    self?.showPopup(forMainText: "정말로 탈퇴하시겠어요?", forSubText: "회원 탈퇴 시 지금까지 저장한 모든 링크가 사라져요.", forLeftButtonTitle: "네, 탈퇴할래요", forRightButtonTitle: "더 써볼래요", forLeftButtonHandler: self?.popupConfirmationButtonTapped, forRightButtonHandler: nil)
                 }
             case .notFound, .unProcessable, .networkFail:
                 print("🍞⛔️회원탈퇴 실패⛔️🍞")


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #120 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/a349a741-8f18-446e-9ab0-f0d6868b383d" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/b98a1c56-5607-4588-8a65-0609911d6314" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/45564605/dacda3ed-dc47-4e3d-8012-213d29d3149a" width ="200"> |

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`SettingViewController`
- 다음과 같이 좌측, 우측 버튼이 존재하는 alert 으로 수정하였습니다!
```swift
if result.access && result.refresh {
    self?.showPopup(forMainText: "정말로 탈퇴하시겠어요?", forSubText: "회원 탈퇴 시 지금까지\n저장한 모든 링크가 사라져요.", forLeftButtonTitle: "네, 탈퇴할래요", forRightButtonTitle: "더 써볼래요", forLeftButtonHandler: self?.popupConfirmationButtonTapped, forRightButtonHandler: nil)
}
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
