### PR TITLE
[Fix] #149 - 클립 편집 드래그앤드랍 버그 수정

### DIFF
--- a/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
+++ b/TOASTER-iOS/Present/AddLink/View/AddLinkView.swift
@@ -82,7 +82,7 @@ private extension AddLinkView {
             $0.backgroundColor = .gray50
             $0.makeRounded(radius: 12)
             $0.inputAccessoryView = accessoryView
-            $0.addPadding(left: -15.0)
+            $0.addPadding(left: 14, right: 42)
             $0.addTarget(self, action: #selector(self.textFieldDidChange), for: .touchUpInside)
         }
     
@@ -131,7 +131,7 @@ private extension AddLinkView {
         
         clearButton.snp.makeConstraints {
             $0.top.equalTo(linkEmbedTextField.snp.top).inset(15)
-            $0.trailing.equalTo(linkEmbedTextField.snp.trailing).inset(15)
+            $0.trailing.equalTo(linkEmbedTextField.snp.trailing).inset(14)
         }
         
         nextBottomButton.snp.makeConstraints {

--- a/TOASTER-iOS/Present/EditClip/ViewController/EditClipViewController.swift
+++ b/TOASTER-iOS/Present/EditClip/ViewController/EditClipViewController.swift
@@ -206,12 +206,10 @@ extension EditClipViewController: UICollectionViewDropDelegate {
             collectionView.performBatchUpdates {
                 let sourceItem = clipList.clips.remove(at: sourceIndexPath.item - 1)
                 clipList.clips.insert(sourceItem, at: destinationIndexPath.item-1)
-                patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel(id: clipList.clips[destinationIndexPath.item-1].id, priority: destinationIndexPath.item-1))
                 collectionView.deleteItems(at: [sourceIndexPath])
                 collectionView.insertItems(at: [destinationIndexPath])
                 coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-            } completion: { _ in
-                collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+                self.patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel(id: self.clipList.clips[destinationIndexPath.item-1].id, priority: destinationIndexPath.item-1))
             }
         }
     }
@@ -278,12 +276,12 @@ extension EditClipViewController {
     
     func patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel) {
         NetworkService.shared.clipService.patchEditPriorityCategory(requestBody: PatchEditPriorityCategoryRequestDTO(categoryId: requestBody.id,
-                                                                                                                     newPriority: requestBody.priority)) { result in
+                                                                                                                     newPriority: requestBody.priority)) { [weak self] result in
             switch result {
             case .success:
-                self.getAllCategoryAPI()
+                self?.editClipCollectionView.reloadData()
             case .unAuthorized, .networkFail, .notFound:
-                self.changeViewController(viewController: LoginViewController())
+                self?.changeViewController(viewController: LoginViewController())
             default: return
             }
         }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #149 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- 드래그앤 드랍 발생하던 버그 수정
  - 버그 1. 스크롤 5번 이상부터 가장 상단의 인덱스에 대해서만 drop Animation이 고정으로 발생
  - 버그 2. 어느 경우에 발생하는지 모르던 데이터가 바뀌지 않고 고정되는 문제

- 링크 저장에서 사용하는 텍스트 필드 오른쪽 끝 부분 간격 추가 (x 버튼 이후까지 넘치던 UI 이슈 해결) 

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
- 자체 문제 원인 진단 : completion 이후에 발생하는 네트워크 통신 부분에서 reload 처리를 하다보니 생기는 그 시간차이가 버그를 발생한 것으로 판단되었음
- 또한, 다시 코드를 보니 get 통신 코드가 불필요하다고 판단되어 삭제했으며, reload 처리를 네트워크 함수에서 처리하면서 동시에 [weak self]도 추가를 해 강한 순환 참조를 방지했음
- 기존에 발생하던 데이터가 바뀌지 않던 문제는 지난번 DTO와 모델을 분리하면서, 저장하는 clipList 파일에 변화를 주어 해결할 수 있었음

`개선 전 코드`
```swift
collectionView.performBatchUpdates {
                let sourceItem = clipList.clips.remove(at: sourceIndexPath.item - 1)
                clipList.clips.insert(sourceItem, at: destinationIndexPath.item-1)
                patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel(id: clipList.clips[destinationIndexPath.item-1].id, priority: destinationIndexPath.item-1))
                collectionView.deleteItems(at: [sourceIndexPath])
                collectionView.insertItems(at: [destinationIndexPath])
                coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
            } completion: { _ in
                // 여기서 reload 처리를 하는게 1차적인 문제로 판단함 (reload와 drop Animation과의 차이 존재)
                collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)  
}
```

`개선 후 코드`
```swift
collectionView.performBatchUpdates {
                // dataSource와 관련된 리스트를 변경
                let sourceItem = clipList.clips.remove(at: sourceIndexPath.item - 1)
                clipList.clips.insert(sourceItem, at: destinationIndexPath.item-1)

                 // UI 변경
                collectionView.deleteItems(at: [sourceIndexPath])
                collectionView.insertItems(at: [destinationIndexPath])

                 // 부드러운 애니메이션을 위해 적용
                coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)

                // reload 처리를 해당 API 함수 success 부분에서 비동기로 수행하도록 변경
                self.patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel(id: self.clipList.clips[destinationIndexPath.item-1].id, priority: destinationIndexPath.item-1))
}
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
