### PR TITLE
[Design] #154 - 클립 추가 버튼 테두리 추가 

### DIFF
--- a/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
@@ -34,6 +34,7 @@ final class UserClipEmptyCollectionViewCell: UICollectionViewCell {
     
     func setView() {
         setupStyle()
+        setupLayer()
         setupHierarchy()
         setupLayout()
     }
@@ -44,8 +45,7 @@ final class UserClipEmptyCollectionViewCell: UICollectionViewCell {
 private extension UserClipEmptyCollectionViewCell {
     func setupStyle() {
         backgroundColor = .clear
-        self.makeRounded(radius: 12)
-        
+                
         addClipImage.do {
             $0.image = ImageLiterals.Home.addBtn
         }
@@ -72,5 +72,23 @@ private extension UserClipEmptyCollectionViewCell {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(addClipImage.snp.bottom).offset(1)
         }
+    }
+    
+    // Button 테두리 점선 Custom
+    func setupLayer() {
+        let customLayer = CAShapeLayer()
+        let frameSize = self.frame.size
+        let shapeRect = CGRect(x: 0, y: 0, width: frameSize.width, height: frameSize.height)
+        
+        customLayer.bounds = shapeRect
+        customLayer.position = CGPoint(x: frameSize.width/2, y: frameSize.height/2)
+        customLayer.fillColor = UIColor.clear.cgColor
+        customLayer.strokeColor = UIColor.gray100.cgColor
+        customLayer.lineWidth = 2
+        customLayer.lineJoin = CAShapeLayerLineJoin.round
+        customLayer.lineDashPattern = [4, 2]
+        customLayer.path = UIBezierPath(roundedRect: shapeRect, cornerRadius: 12).cgPath
+        
+        self.layer.addSublayer(customLayer)
     }
 }

--- a/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
@@ -88,7 +88,7 @@ private extension UserClipEmptyCollectionViewCell {
         customLayer.strokeColor = UIColor.gray100.cgColor
         customLayer.lineWidth = 2
         customLayer.lineJoin = CAShapeLayerLineJoin.round
-        customLayer.lineDashPattern = [4, 2]
+        customLayer.lineDashPattern = [4, 4]
         customLayer.path = UIBezierPath(roundedRect: shapeRect, cornerRadius: 12).cgPath
         
         self.layer.addSublayer(customLayer)

--- a/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/UserClipEmptyCollectionViewCell.swift
@@ -10,6 +10,8 @@ import UIKit
 import SnapKit
 import Then
 
+// MARK: - 클립 추가 Empty Cell
+
 final class UserClipEmptyCollectionViewCell: UICollectionViewCell {
     
     // MARK: - UI Components


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #154 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- Home 화면의 클립 추가 Button의 점선 테두리
![RPReplay_Final1707058856](https://github.com/Link-MIND/TOASTER-iOS/assets/101050833/488e8153-42d9-4096-8673-1a9bff499509)




## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`UserClipEmptyCollectionViewCell`
- Button 테두리 dash line 으로 커스텀 했습니다. 
```swift
// Button 테두리 점선 Custom
    func setupLayer() {
        let customLayer = CAShapeLayer()
        let frameSize = self.frame.size
        let shapeRect = CGRect(x: 0, y: 0, width: frameSize.width, height: frameSize.height)
        
        customLayer.bounds = shapeRect
        customLayer.position = CGPoint(x: frameSize.width/2, y: frameSize.height/2)
        customLayer.fillColor = UIColor.clear.cgColor
        customLayer.strokeColor = UIColor.gray100.cgColor
        customLayer.lineWidth = 2
        customLayer.lineJoin = CAShapeLayerLineJoin.round
        customLayer.lineDashPattern = [4, 2]
        customLayer.path = UIBezierPath(roundedRect: shapeRect, cornerRadius: 12).cgPath
        
        self.layer.addSublayer(customLayer)
    }
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
