### PR TITLE
[Fix] # 156 - 2차 QA 반영 

### DIFF
--- a/TOASTER-iOS/Global/Consts/ImageLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/ImageLiterals.swift
@@ -30,7 +30,7 @@ enum ImageLiterals {
     enum TabBar {
         static var home: UIImage { .load(name: "ic_home_24") }
         static var allClip: UIImage { .load(name: "ic_all_clip_24") }
-        static var clip: UIImage { .load(name: "ic_clip_24") }
+        static var clip: UIImage { .load(name: "ic_clip_full_24") }
         static var plus: UIImage { .load(name: "fab_plus") }
         static var timer: UIImage { .load(name: "ic_timer_24") }
         static var my: UIImage { .load(name: "ic_my_24") }
@@ -105,7 +105,7 @@ enum ImageLiterals {
     
     enum Home {
         static var clipDefault: UIImage { .load(name: "ic_all_clip_24") }
-        static var clipFull: UIImage { .load(name: "ic_clip_24") }
+        static var clipFull: UIImage { .load(name: "ic_clip_full_24") }
         static var linkThumbNail: UIImage { .load(name: "img_thumbnail") }
         static var siteThumbNail: UIImage { .load(name: "img_bmsite") }
         static var addBtn: UIImage { .load(name: "btn_plus") }

--- a/TOASTER-iOS/Global/Consts/ImageLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/ImageLiterals.swift
@@ -105,7 +105,7 @@ enum ImageLiterals {
     
     enum Home {
         static var clipDefault: UIImage { .load(name: "ic_all_clip_24") }
-        static var clipFull: UIImage { .load(name: "ic_clip_full_24") }
+        static var clipFull: UIImage { .load(name: "ic_clip_24") }
         static var linkThumbNail: UIImage { .load(name: "img_thumbnail") }
         static var siteThumbNail: UIImage { .load(name: "img_bmsite") }
         static var addBtn: UIImage { .load(name: "btn_plus") }

--- a/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
@@ -150,5 +150,4 @@ private extension MainCollectionViewCell {
     @objc func buttonTapped() {
         mainCollectionViewDelegate?.searchButtonTapped()
     }
-    
 }

--- a/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/MainCollectionViewCell.swift
@@ -131,7 +131,7 @@ private extension MainCollectionViewCell {
         }
         
         noticeLabel.snp.makeConstraints {
-            $0.top.equalTo(userLabel.snp.bottom).offset(5)
+            $0.top.equalTo(userLabel.snp.bottom).offset(4)
             $0.leading.equalTo(userLabel.snp.leading)
         }
         
@@ -141,9 +141,8 @@ private extension MainCollectionViewCell {
         }
         
         linkProgressView.snp.makeConstraints {
-            $0.top.equalTo(countToastLabel.snp.bottom).offset(5)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(335)
+            $0.top.equalTo(countToastLabel.snp.bottom).offset(6)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(12)
         }
     }

--- a/TOASTER-iOS/Present/Home/View/Cell/WeeklyRecommendCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/Home/View/Cell/WeeklyRecommendCollectionViewCell.swift
@@ -60,18 +60,15 @@ private extension WeeklyRecommendCollectionViewCell {
         self.makeRounded(radius: 8)
         
         brandImage.do {
-            $0.image = ImageLiterals.Home.siteThumbNail
             $0.makeRounded(radius: 20)
         }
         
         titleLabel.do {
-            $0.text = "Title" // 서버 통신 이후 dummyData로 뺄 것
             $0.font = .suitBold(size: 12)
             $0.textColor = .gray800
         }
         
         subLabel.do {
-            $0.text = "sub" // 서버 통신 이후 dummyData로 뺄 것
             $0.font = .suitMedium(size: 10)
             $0.textColor = .gray400
         }

--- a/TOASTER-iOS/Present/Home/View/CompositioinalFactory.swift
+++ b/TOASTER-iOS/Present/Home/View/CompositioinalFactory.swift
@@ -52,7 +52,7 @@ enum CompositionalFactory {
         
         // Footer
         section.boundarySupplementaryItems = [
-            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(12)), elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
+            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(4)), elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
         ]
         return section
     }
@@ -80,8 +80,8 @@ enum CompositionalFactory {
         
         // Header, Footer
         section.boundarySupplementaryItems = [
-            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(50)), elementKind: UICollectionView.elementKindSectionHeader, alignment: .top),
-            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(20)), elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
+            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(46)), elementKind: UICollectionView.elementKindSectionHeader, alignment: .top),
+            NSCollectionLayoutBoundarySupplementaryItem(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .absolute(17)), elementKind: UICollectionView.elementKindSectionFooter, alignment: .bottom)
         ]
         return section
     }

--- a/TOASTER-iOS/Present/Home/View/Footer/HomeFooterCollectionView.swift
+++ b/TOASTER-iOS/Present/Home/View/Footer/HomeFooterCollectionView.swift
@@ -55,7 +55,7 @@ final class HomeFooterCollectionView: UICollectionReusableView {
     
     private func setupLayout() {
         divideView.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(7)
+            //$0.top.equalToSuperview().offset(24)
             $0.width.equalToSuperview()
             $0.height.equalTo(4)
         }

--- a/TOASTER-iOS/Present/Home/View/Footer/HomeFooterCollectionView.swift
+++ b/TOASTER-iOS/Present/Home/View/Footer/HomeFooterCollectionView.swift
@@ -55,8 +55,9 @@ final class HomeFooterCollectionView: UICollectionReusableView {
     
     private func setupLayout() {
         divideView.snp.makeConstraints {
-            //$0.top.equalToSuperview().offset(24)
-            $0.width.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(UIScreen.main.bounds.width)
             $0.height.equalTo(4)
         }
     }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #156 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
`Home 화면`
- Cell의 높이를 수정
- 디바이더 width 수정
- Header, Footer height 수정
- ProgressBar 정렬

`Icon`
- TabBar와 Home화면에서 사용되는 Clip icon 통일

`ETC`
- 불필요한 코드 삭제 

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`Home`
-  Main Section같은 경우, 현재 Figma에는 Search Bar와 Cell이 따로 분리되어 있습니다. 
검색 화면으로 넘어가도록 Search Bar를 UIButton으로 구현했습니다. 해당 버튼은 Cell에 포함되도록 하여 Group의 Height은 Figma에 명시된 길이를 모두 더해 224로 하였습니다. 
```swift
let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                               heightDimension: .estimated(224))
```

- 디바이더 길이 수정
```swift
divideView.snp.makeConstraints {
            $0.bottom.equalToSuperview()
            $0.centerX.equalToSuperview()
            $0.width.equalTo(UIScreen.main.bounds.width)
            $0.height.equalTo(4)
        }
```


## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
