### PR TITLE
[Feat] #170 - 네트워크 연결 오류 알럿 추가

### DIFF
--- a/TOASTER-iOS/Network/Base/MoyaPlugin.swift
+++ b/TOASTER-iOS/Network/Base/MoyaPlugin.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+import UIKit
 
 import Moya
-import UIKit
 
 final class MoyaPlugin: PluginType {
     

--- a/TOASTER-iOS/Network/Base/MoyaPlugin.swift
+++ b/TOASTER-iOS/Network/Base/MoyaPlugin.swift
@@ -69,12 +69,14 @@ final class MoyaPlugin: PluginType {
         log.append("<-- END HTTP 🍞🍞🍞")
         print(log)
         
-        let popupViewController = ToasterPopupViewController(mainText: "네트워크 연결 오류", subText: "네트워크 오류로\n서비스 접속이 불가능해요", centerButtonTitle: StringLiterals.Button.okay, centerButtonHandler: nil)
+        // 네트워크 연결 오류 Alert창 표출
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let delegate = windowScene.delegate as? SceneDelegate,
            let rootViewController = delegate.window?.rootViewController {
-            popupViewController.modalPresentationStyle = .overFullScreen
-            rootViewController.present(popupViewController, animated: false)
+            rootViewController.showConfirmationPopup(
+                forMainText: "네트워크 연결 오류",
+                forSubText: "네트워크 오류로\n서비스 접속이 불가능해요",
+                centerButtonTitle: StringLiterals.Button.okay)
         }
     }
 }

--- a/TOASTER-iOS/Network/Base/MoyaPlugin.swift
+++ b/TOASTER-iOS/Network/Base/MoyaPlugin.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import Moya
+import UIKit
 
 final class MoyaPlugin: PluginType {
     
@@ -67,5 +68,13 @@ final class MoyaPlugin: PluginType {
         log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
         log.append("<-- END HTTP 🍞🍞🍞")
         print(log)
+        
+        let popupViewController = ToasterPopupViewController(mainText: "네트워크 연결 오류", subText: "네트워크 오류로\n서비스 접속이 불가능해요", centerButtonTitle: StringLiterals.Button.okay, centerButtonHandler: nil)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let delegate = windowScene.delegate as? SceneDelegate,
+           let rootViewController = delegate.window?.rootViewController {
+            popupViewController.modalPresentationStyle = .overFullScreen
+            rootViewController.present(popupViewController, animated: false)
+        }
     }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #170 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
네트워크 연결 오류 발생시 피그마에 있던 알럿창 추가했습니다!

|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/04e6e717-6277-4ad7-af9a-74777ff35953" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/0695ecf7-d781-4296-9e4f-709f7ae759fd" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/9648589d-9b76-4c39-bd66-3065ad08cea7" width ="200"> |

## 📂 참고한 내용
<!-- 참고한 사이트나 정보가 있다면 작성주세요 -->
- Moya 공식문서를 참조해서, Alert를 판단하는 부분을 Plugin 파일에 추가했습니다. 해당 내용은 [이 링크](https://github.com/Moya/Moya/blob/master/docs/Examples/CustomPlugin.md)에서 확인하실 수 있습니다!
- 지금 Figma 상에는 네트워크 에러 처리에 대한 Alert만 구현되어 있고 세부 동작이 설명되어있지 않아, 우선 완료 버튼을 눌러도 Default인 Alert를 꺼지게 동작해두었습니다.
- 세부적인 동작 (설정앱으로 연결, 앱 죽이기, 상태 최신화)은 [해당 레퍼런스 자료](https://maily.so/tipster/posts/de967483)를 바탕으로 기디와 논의가 필요할 것 같습니다!

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
