### PR TITLE
[Feat] #180 - 강제 업데이트 Alert 구현 

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -1910,7 +1910,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "TeamLinkMIND.TOASTER-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1944,7 +1944,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "TeamLinkMIND.TOASTER-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		3909A06D2B62375E005A4546 /* LinkReadEditModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3909A06C2B62375E005A4546 /* LinkReadEditModel.swift */; };
 		3909A0702B6239F8005A4546 /* ClipPriorityEditModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3909A06F2B6239F8005A4546 /* ClipPriorityEditModel.swift */; };
 		390ADE652B585C8D00FE1E4B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 390ADE642B585C8D00FE1E4B /* GoogleService-Info.plist */; };
+		3913B0AE2BCEC9C00031A3EB /* UpdateAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3913B0AD2BCEC9C00031A3EB /* UpdateAlertManager.swift */; };
+		3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */; };
 		391908422B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */; };
 		391908442B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */; };
 		398ACFDC2B5E77FA00D5EE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */; };
@@ -212,6 +214,8 @@
 		3909A06C2B62375E005A4546 /* LinkReadEditModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkReadEditModel.swift; sourceTree = "<group>"; };
 		3909A06F2B6239F8005A4546 /* ClipPriorityEditModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipPriorityEditModel.swift; sourceTree = "<group>"; };
 		390ADE642B585C8D00FE1E4B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		3913B0AD2BCEC9C00031A3EB /* UpdateAlertManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAlertManager.swift; sourceTree = "<group>"; };
+		3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAlertType.swift; sourceTree = "<group>"; };
 		391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditPriorityCategoryRequestDTO.swift; sourceTree = "<group>"; };
 		391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditNameCategoryRequestDTO.swift; sourceTree = "<group>"; };
 		398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
@@ -463,6 +467,15 @@
 				3909A06F2B6239F8005A4546 /* ClipPriorityEditModel.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		3913B0AC2BCEC9A30031A3EB /* UpdateAlert */ = {
+			isa = PBXGroup;
+			children = (
+				3913B0AD2BCEC9C00031A3EB /* UpdateAlertManager.swift */,
+				3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */,
+			);
+			path = UpdateAlert;
 			sourceTree = "<group>";
 		};
 		398ACFDA2B5E77C500D5EE77 /* Assets */ = {
@@ -822,6 +835,7 @@
 		6B6AE6872B3FF55F000E2366 /* Present */ = {
 			isa = PBXGroup;
 			children = (
+				3913B0AC2BCEC9A30031A3EB /* UpdateAlert */,
 				39B54E712B53C4F100538DAE /* Setting */,
 				39EF95FD2B501BC400F301FC /* EditClip */,
 				390925C22B4EF61B00487AA3 /* LinkWeb */,
@@ -1580,6 +1594,7 @@
 				6BE6DA342B50594B008B06FA /* MoyaPlugin.swift in Sources */,
 				6BE6D9D82B4E8A03008B06FA /* RemindAlarmOffViewType.swift in Sources */,
 				398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */,
+				3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */,
 				6BE6DA5B2B50B46F008B06FA /* GetMainPageResponseDTO.swift in Sources */,
 				3F2FA1772B45C3E000EDBF95 /* AuthenticationAdapterProtocol.swift in Sources */,
 				6BC493792B4D6FB300544249 /* SearchEmptyResultView.swift in Sources */,
@@ -1676,6 +1691,7 @@
 				6BE6DA9C2B54752B008B06FA /* GetTimerMainpageResponseDTO.swift in Sources */,
 				6B6AE6AA2B3FF6EA000E2366 /* UIStackView+.swift in Sources */,
 				8305178A2B4D1E09009FFB60 /* UserClipCollectionViewCell.swift in Sources */,
+				3913B0AE2BCEC9C00031A3EB /* UpdateAlertManager.swift in Sources */,
 				3F2FA17D2B4928B700EDBF95 /* LoginUseCase.swift in Sources */,
 				6BE6DA9A2B54747B008B06FA /* TimerAPIService.swift in Sources */,
 				6BE6DA882B546B24008B06FA /* PatchOpenLinkResponseDTO.swift in Sources */,

--- a/TOASTER-iOS/Application/SceneDelegate.swift
+++ b/TOASTER-iOS/Application/SceneDelegate.swift
@@ -13,12 +13,19 @@ import KakaoSDKCommon
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
+    let updateAlertManager = UpdateAlertManager()
     
+    func checkUpdate(rootViewController: UIViewController) {
+        if let updateStatus = updateAlertManager.checkUpdateAlertNeeded() {
+            updateAlertManager.showUpdateAlert(type: updateStatus,
+                                               on: rootViewController)
+        }
+    }
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    
+        
         let rootViewController = appDelegate.isLogin ? TabBarController() : LoginViewController()
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -28,6 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window?.overrideUserInterfaceStyle = .light
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
+        checkUpdate(rootViewController: rootViewController)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/TOASTER-iOS/Application/SceneDelegate.swift
+++ b/TOASTER-iOS/Application/SceneDelegate.swift
@@ -15,8 +15,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     let updateAlertManager = UpdateAlertManager()
     
-    func checkUpdate(rootViewController: UIViewController) {
-        if let updateStatus = updateAlertManager.checkUpdateAlertNeeded() {
+    func checkUpdate(rootViewController: UIViewController) async {
+        if let updateStatus = await updateAlertManager.checkUpdateAlertNeeded() {
             updateAlertManager.showUpdateAlert(type: updateStatus,
                                                on: rootViewController)
         }
@@ -35,7 +35,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window?.overrideUserInterfaceStyle = .light
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
-        checkUpdate(rootViewController: rootViewController)
+        Task {
+            await checkUpdate(rootViewController: rootViewController)
+        }
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/TOASTER-iOS/Global/Consts/StringLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/StringLiterals.swift
@@ -53,6 +53,4 @@ enum StringLiterals {
         static let noticeSetTimer = "한 클립당 하나의 타이머만 설정 가능해요"
         static let noticeMaxTimer = "타이머는 최대 다섯 개까지 설정 가능해요"
     }
-    
-    static let appStoreLink = "https://apps.apple.com/kr/app/toaster-%ED%86%A0%EC%8A%A4%ED%84%B0-%EB%A7%81%ED%81%AC-%EC%95%84%EC%B9%B4%EC%9D%B4%EB%B9%99-%EB%A6%AC%EB%A7%88%EC%9D%B8%EB%93%9C/id6476194200"
 }

--- a/TOASTER-iOS/Global/Consts/StringLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/StringLiterals.swift
@@ -53,4 +53,6 @@ enum StringLiterals {
         static let noticeSetTimer = "한 클립당 하나의 타이머만 설정 가능해요"
         static let noticeMaxTimer = "타이머는 최대 다섯 개까지 설정 가능해요"
     }
+    
+    static let appStoreLink = "https://apps.apple.com/kr/app/toaster-%ED%86%A0%EC%8A%A4%ED%84%B0-%EB%A7%81%ED%81%AC-%EC%95%84%EC%B9%B4%EC%9D%B4%EB%B9%99-%EB%A6%AC%EB%A7%88%EC%9D%B8%EB%93%9C/id6476194200"
 }

--- a/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
+++ b/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
@@ -37,29 +37,38 @@ final class UpdateAlertManager {
     }
     
     /// iTunes API를 사용하여 앱스토어의 현재 앱 버전 불러오기
-    func checkAppStoreVersion() -> String {
-        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&country=kr"),
-              let data = try? Data(contentsOf: url),
-              let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
-              let results = json["results"] as? [[String: Any]],
-              let appStoreVersion = results[0]["version"] as? String else {
-            return ""
+    func checkAppStoreVersion() async -> String {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&country=kr") else { return "" }
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            if let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+               let results = json["results"] as? [[String: Any]],
+               let appStoreVersion = results[0]["version"] as? String { return appStoreVersion }
+        } catch {
+            print("앱스토어 버전을 가져오지 못했습니다😡")
         }
-        return appStoreVersion
+        
+        return ""
     }
     
     /// 앱스토어 버전과 현재 버전 비교하기
-    func checkUpdateAlertNeeded() -> UpdateAlertType? {
+    func checkUpdateAlertNeeded() async -> UpdateAlertType? {
         let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
-        let appStoreVersion = checkAppStoreVersion()
+        let appStoreVersion = await checkAppStoreVersion()
         
         let currentVersionArray = currentVersion.split(separator: ".").map { $0 }
         let appStoreVersionArray = appStoreVersion.split(separator: ".").map { $0 }
-        
-        if currentVersionArray[0] < appStoreVersionArray[0] {
+
+        if (currentVersionArray[0] < appStoreVersionArray[0]) {
             return .ForceUpdate
-        } else if currentVersionArray[0] == appStoreVersionArray[0] {
-            return currentVersionArray[1] < appStoreVersionArray[1] ? .NoticeFeatUpdate : nil
+        } else if (currentVersionArray[0] == appStoreVersionArray[0])
+                    && (currentVersionArray[1] < appStoreVersionArray[1]) {
+            return .NoticeFeatUpdate
+        } else if (currentVersionArray[0] == appStoreVersionArray[0])
+                    && (currentVersionArray[1] == appStoreVersionArray[1])
+                    && (currentVersionArray[2] < appStoreVersionArray[2]) {
+            return .NoticeUpdate
         } else {
             return nil
         }

--- a/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
+++ b/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
@@ -1,0 +1,33 @@
+//
+//  UpdateAlertManager.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 4/16/24.
+//
+
+import UIKit
+
+final class UpdateAlertManager {
+    
+    /// Alert 표출 함수
+    func showUpdateAlert(type: UpdateAlertType,
+                         on viewController: UIViewController) {
+        let alertViewController = UIAlertController(title: type.title,
+                                                    message: type.description,
+                                                    preferredStyle: .alert)
+        if type != .ForceUpdate {
+            let laterAction = UIAlertAction(title: "다음에", style: .default)
+            alertViewController.addAction(laterAction)
+        }
+        
+        let updateAction = UIAlertAction(title: "업데이트",
+                                         style: .default) {_ in
+            if let url = URL(string: StringLiterals.appStoreLink) {
+                UIApplication.shared.open(url)
+            }
+        }
+        alertViewController.addAction(updateAction)
+        
+        viewController.present(alertViewController, animated: true)
+    }
+}

--- a/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
+++ b/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
@@ -22,8 +22,14 @@ final class UpdateAlertManager {
         
         let updateAction = UIAlertAction(title: "업데이트",
                                          style: .default) {_ in
-            if let url = URL(string: StringLiterals.appStoreLink) {
-                UIApplication.shared.open(url)
+            if let url = URL(
+                string: "itms-apps://itunes.apple.com/app/6476194200"),
+               UIApplication.shared.canOpenURL(url) {
+                if #available(iOS 10.0, *) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                } else {
+                    UIApplication.shared.openURL(url)
+                }
             }
         }
         alertViewController.addAction(updateAction)

--- a/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
+++ b/TOASTER-iOS/Present/UpdateAlert/UpdateAlertManager.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class UpdateAlertManager {
+    private let appId = "6476194200"
     
     /// Alert 표출 함수
     func showUpdateAlert(type: UpdateAlertType,
@@ -20,10 +21,9 @@ final class UpdateAlertManager {
             alertViewController.addAction(laterAction)
         }
         
-        let updateAction = UIAlertAction(title: "업데이트",
-                                         style: .default) {_ in
+        let updateAction = UIAlertAction(title: "업데이트", style: .default) { _ in
             if let url = URL(
-                string: "itms-apps://itunes.apple.com/app/6476194200"),
+                string: "itms-apps://itunes.apple.com/app/\(self.appId)"),
                UIApplication.shared.canOpenURL(url) {
                 if #available(iOS 10.0, *) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
@@ -33,7 +33,35 @@ final class UpdateAlertManager {
             }
         }
         alertViewController.addAction(updateAction)
-        
         viewController.present(alertViewController, animated: true)
+    }
+    
+    /// iTunes API를 사용하여 앱스토어의 현재 앱 버전 불러오기
+    func checkAppStoreVersion() -> String {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&country=kr"),
+              let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+              let results = json["results"] as? [[String: Any]],
+              let appStoreVersion = results[0]["version"] as? String else {
+            return ""
+        }
+        return appStoreVersion
+    }
+    
+    /// 앱스토어 버전과 현재 버전 비교하기
+    func checkUpdateAlertNeeded() -> UpdateAlertType? {
+        let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        let appStoreVersion = checkAppStoreVersion()
+        
+        let currentVersionArray = currentVersion.split(separator: ".").map { $0 }
+        let appStoreVersionArray = appStoreVersion.split(separator: ".").map { $0 }
+        
+        if currentVersionArray[0] < appStoreVersionArray[0] {
+            return .ForceUpdate
+        } else if currentVersionArray[0] == appStoreVersionArray[0] {
+            return currentVersionArray[1] < appStoreVersionArray[1] ? .NoticeFeatUpdate : nil
+        } else {
+            return nil
+        }
     }
 }

--- a/TOASTER-iOS/Present/UpdateAlert/UpdateAlertType.swift
+++ b/TOASTER-iOS/Present/UpdateAlert/UpdateAlertType.swift
@@ -1,0 +1,37 @@
+//
+//  UpdateAlertType.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 4/17/24.
+//
+
+import UIKit
+
+enum UpdateAlertType {
+    case ForceUpdate        // Major Update case -> 강제 업데이트
+    case NoticeUpdate       // Minor 사용성 Update case -> 선택 업데이트
+    case NoticeFeatUpdate   // Minor 기능 Update case -> 선택 업데이트
+    
+    var title: String {
+        switch self {
+        case .ForceUpdate:
+            return "신규 기능 업데이트 알림"
+        case .NoticeUpdate:
+            return "업데이트 알림"
+        case .NoticeFeatUpdate:
+            return "기능 업데이트 알림"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .ForceUpdate:
+            return "토스터의 새로운 기능을 이용하기 위해서는\n업데이트가 필요해요!\n최신 버전으로 업데이트 하시겠어요?"
+        case .NoticeUpdate:
+            return "토스터의 사용성이 개선되었어요!\n지금 바로 업데이트해보세요"
+        case .NoticeFeatUpdate:
+            return "토스터의 기능이 추가되었어요!\n지금 바로 업데이트해보세요"
+        }
+    }
+    
+}


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #180 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

|    구현 내용    |   patch Update   |   minor Update  |   major Update   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/e838898d-9e48-45a0-acb2-ac08b6885010" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/8ae35ddb-2a54-4322-8e93-35c4b53e2943" width ="200"> | <img src = "https://github.com/Link-MIND/TOASTER-iOS/assets/69389288/f8978eff-340a-4137-b0eb-1c776fb63314" width ="200"> |

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
#### 1. Alert창 구현
- 피그마에 올라와있는 3개의 Alert창을 `UpdateAlertType` enum으로 구분했습니다.   
- `UpdateAlertManager`에 담겨있는 `showUpdateAlert(type: on viewController)`공통 메서드를 활용해 각 상황에 맞는 type와 표출되는 VC를 지정하도록 했습니다.

#### 2. App Version, Release Version 불러오기
- 업데이트 버전 체크는 현재 설치되어 있는 앱의 버전과 App Store 릴리즈 되어있는 버전 두 개를 비교합니다!
- 사용자의 핸드폰에 설치된 앱 버전은 Info.plst에 저장(`CFBundleShortVersionString`)된 버전 정보를 가져옵니다.
```swift
let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
```

- 최신 업데이트 버전은 iTunes API를 활용하여 비동기적으로 앱스토어의 앱 버전을 불러옵니다.
```swift
func checkAppStoreVersion() async -> String {
    guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(appId)&country=kr") else { return "" }
    
    do {
        let (data, _) = try await URLSession.shared.data(from: url)
        if let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
           let results = json["results"] as? [[String: Any]],
           let appStoreVersion = results[0]["version"] as? String { return appStoreVersion }
    } catch {
        print("앱스토어 버전을 가져오지 못했습니다😡")
    }
    
    return ""
}
```

#### 3. SceneDelegate에서 버전 비교하고, Alert 표출여부 결정하기
- 앱이 활성화될 때마다 반복해서 업데이트 알럿을 보여주기 위해  `SceneDelegate`에 해당 로직을 추가했습니다.
- 로그인 여부에 따라 바뀌는 RootVC 이동 이후, 뷰컨이 표출된 다음에 "업데이트 확인->Alert 표출 결정"하는 로직을 추가했습니다.

## 🤔 근데 생각해보면...
버전을 체크하는 로직은 이번 1.1.0 빌드 버전부터 들어가게 되는디....
업데이트 하기 이전인 1.0.2 이하 버전에서, 즉 이번 업데이트를 올린다고 별도의 설정을 해주지 않는 한 업데이트 Alert이 보이지 않을 것 같네유..?

어차피 강제 업데이트는 하지 않는 두째자리 minor 업데이트이긴 한데... 이 부분은 기획에 공유를 드리면 될지..
아니면 다른 별도의 해결방법이 있을지 궁금하네유..?

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
