### PR TITLE
[Feat] #179 - 이중 바텀시트 및 링크 제목 수정 구현

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -194,6 +194,8 @@
 		8315CD8C2B54782F0061F377 /* SelectClipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8B2B54782F0061F377 /* SelectClipViewController.swift */; };
 		8315CD8E2B547EE30061F377 /* SelectClipHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8D2B547EE30061F377 /* SelectClipHeaderView.swift */; };
 		8315CD912B5521F70061F377 /* SelectClipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD902B5521F70061F377 /* SelectClipModel.swift */; };
+		8388E98C2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */; };
+		8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */; };
 		83CFC3372B564F1100A2EB2B /* WeeklyLinkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */; };
 		83CFC3392B568BE700A2EB2B /* RecommendSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC3382B568BE700A2EB2B /* RecommendSiteModel.swift */; };
 		83CFC33B2B57324700A2EB2B /* SaveLinkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC33A2B57324700A2EB2B /* SaveLinkModel.swift */; };
@@ -371,6 +373,8 @@
 		8315CD8B2B54782F0061F377 /* SelectClipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipViewController.swift; sourceTree = "<group>"; };
 		8315CD8D2B547EE30061F377 /* SelectClipHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipHeaderView.swift; sourceTree = "<group>"; };
 		8315CD902B5521F70061F377 /* SelectClipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipModel.swift; sourceTree = "<group>"; };
+		8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditLinkTitleRequestDTO.swift; sourceTree = "<group>"; };
+		8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditLinkBottomSheetView.swift; sourceTree = "<group>"; };
 		83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyLinkModel.swift; sourceTree = "<group>"; };
 		83CFC3382B568BE700A2EB2B /* RecommendSiteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendSiteModel.swift; sourceTree = "<group>"; };
 		83CFC33A2B57324700A2EB2B /* SaveLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveLinkModel.swift; sourceTree = "<group>"; };
@@ -543,6 +547,7 @@
 				39BE4BBD2B4ABB7C002B471D /* DetailClipSegmentedControlView.swift */,
 				39BE4BBF2B4ABB9E002B471D /* DetailClipEmptyView.swift */,
 				39BE4BC12B4ABBB0002B471D /* DeleteLinkBottomSheetView.swift */,
+				8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1261,6 +1266,7 @@
 			children = (
 				6BE6DA812B545786008B06FA /* PostSaveLinkRequestDTO.swift */,
 				390247A92B58016C00F9A86A /* PatchOpenLinkRequestDTO.swift */,
+				8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1608,6 +1614,7 @@
 				6BE6DA0B2B4F3063008B06FA /* RemindSelectClipViewModel.swift in Sources */,
 				6BE6DA4D2B50B1EB008B06FA /* UserTargetType.swift in Sources */,
 				6B6AE6932B3FF5A9000E2366 /* ClipViewController.swift in Sources */,
+				8388E98C2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift in Sources */,
 				6BE6DAAF2B547A81008B06FA /* SearchAPIService.swift in Sources */,
 				6BE6DA822B545786008B06FA /* PostSaveLinkRequestDTO.swift in Sources */,
 				830517632B42D871009FFB60 /* TabBarItem.swift in Sources */,
@@ -1676,6 +1683,7 @@
 				6BE6DA9C2B54752B008B06FA /* GetTimerMainpageResponseDTO.swift in Sources */,
 				6B6AE6AA2B3FF6EA000E2366 /* UIStackView+.swift in Sources */,
 				8305178A2B4D1E09009FFB60 /* UserClipCollectionViewCell.swift in Sources */,
+				8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */,
 				3F2FA17D2B4928B700EDBF95 /* LoginUseCase.swift in Sources */,
 				6BE6DA9A2B54747B008B06FA /* TimerAPIService.swift in Sources */,
 				6BE6DA882B546B24008B06FA /* PatchOpenLinkResponseDTO.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		8315CD8C2B54782F0061F377 /* SelectClipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8B2B54782F0061F377 /* SelectClipViewController.swift */; };
 		8315CD8E2B547EE30061F377 /* SelectClipHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8D2B547EE30061F377 /* SelectClipHeaderView.swift */; };
 		8315CD912B5521F70061F377 /* SelectClipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD902B5521F70061F377 /* SelectClipModel.swift */; };
+		8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */; };
 		8388E98C2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */; };
 		8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */; };
 		83CFC3372B564F1100A2EB2B /* WeeklyLinkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */; };
@@ -373,6 +374,7 @@
 		8315CD8B2B54782F0061F377 /* SelectClipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipViewController.swift; sourceTree = "<group>"; };
 		8315CD8D2B547EE30061F377 /* SelectClipHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipHeaderView.swift; sourceTree = "<group>"; };
 		8315CD902B5521F70061F377 /* SelectClipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipModel.swift; sourceTree = "<group>"; };
+		8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditLinkTitleResponseDTO.swift; sourceTree = "<group>"; };
 		8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditLinkTitleRequestDTO.swift; sourceTree = "<group>"; };
 		8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditLinkBottomSheetView.swift; sourceTree = "<group>"; };
 		83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyLinkModel.swift; sourceTree = "<group>"; };
@@ -1276,6 +1278,7 @@
 			children = (
 				6BE6DA872B546B24008B06FA /* PatchOpenLinkResponseDTO.swift */,
 				6BE6DA8B2B546CA9008B06FA /* GetWeeksLinkResponseDTO.swift */,
+				8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1586,6 +1589,7 @@
 				6BE6DA342B50594B008B06FA /* MoyaPlugin.swift in Sources */,
 				6BE6D9D82B4E8A03008B06FA /* RemindAlarmOffViewType.swift in Sources */,
 				398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */,
+				8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
 				6BE6DA5B2B50B46F008B06FA /* GetMainPageResponseDTO.swift in Sources */,
 				3F2FA1772B45C3E000EDBF95 /* AuthenticationAdapterProtocol.swift in Sources */,
 				6BC493792B4D6FB300544249 /* SearchEmptyResultView.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -99,9 +99,7 @@
 		3F3ED2952BA1A46B004E79F0 /* PatchOpenLinkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390247A92B58016C00F9A86A /* PatchOpenLinkRequestDTO.swift */; };
 		3F3ED2962BA1A46B004E79F0 /* PostSaveLinkRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA812B545786008B06FA /* PostSaveLinkRequestDTO.swift */; };
 		3F3ED2972BA1A46E004E79F0 /* GetWeeksLinkResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA8B2B546CA9008B06FA /* GetWeeksLinkResponseDTO.swift */; };
-		3F3ED2982BA1A46E004E79F0 /* ToasterTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA7B2B54571D008B06FA /* ToasterTargetType.swift */; };
 		3F3ED2992BA1A46E004E79F0 /* PatchOpenLinkResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA872B546B24008B06FA /* PatchOpenLinkResponseDTO.swift */; };
-		3F3ED29A2BA1A46E004E79F0 /* ToasterAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA7D2B54572B008B06FA /* ToasterAPIService.swift */; };
 		3F3ED29B2BA1A475004E79F0 /* PatchEditTimerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA952B547037008B06FA /* PatchEditTimerRequestDTO.swift */; };
 		3F3ED29C2BA1A475004E79F0 /* PatchEditTimerTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA972B54709D008B06FA /* PatchEditTimerTitleRequestDTO.swift */; };
 		3F3ED29D2BA1A475004E79F0 /* PostCreateTimerRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA932B546FCB008B06FA /* PostCreateTimerRequestDTO.swift */; };
@@ -272,6 +270,10 @@
 		8315CD8C2B54782F0061F377 /* SelectClipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8B2B54782F0061F377 /* SelectClipViewController.swift */; };
 		8315CD8E2B547EE30061F377 /* SelectClipHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD8D2B547EE30061F377 /* SelectClipHeaderView.swift */; };
 		8315CD912B5521F70061F377 /* SelectClipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8315CD902B5521F70061F377 /* SelectClipModel.swift */; };
+		83474A6A2BED06EB009B9C48 /* ToasterTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA7B2B54571D008B06FA /* ToasterTargetType.swift */; };
+		83474A6B2BED06F1009B9C48 /* PatchEditLinkTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */; };
+		83474A6C2BED072A009B9C48 /* ToasterAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA7D2B54572B008B06FA /* ToasterAPIService.swift */; };
+		83474A6D2BED0750009B9C48 /* PatchEditLinkTitleResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */; };
 		8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */; };
 		8388E98C2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */; };
 		8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */; };
@@ -1783,6 +1785,7 @@
 				3F3ED2AE2BA1CD10004E79F0 /* BottomType.swift in Sources */,
 				3F3ED2822BA1A3F8004E79F0 /* ClipTargetType.swift in Sources */,
 				3FE00F0C2BC632A500CC821E /* NetworkResult.swift in Sources */,
+				83474A6D2BED0750009B9C48 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
 				3F3ED2832BA1A3FD004E79F0 /* GetAllCategoryResponseDTO.swift in Sources */,
 				3F1F261C2BAA9887004F75CE /* RemindSelectClipViewModel.swift in Sources */,
 				3F3ED28F2BA1A45F004E79F0 /* UserAPIService.swift in Sources */,
@@ -1793,11 +1796,13 @@
 				3F3ED2B62BA1D6C8004E79F0 /* UILabel+.swift in Sources */,
 				3FE00F0B2BC6328900CC821E /* MoyaPlugin.swift in Sources */,
 				3F1F261B2BAA9820004F75CE /* RemindSelectClipCollectionViewCell.swift in Sources */,
+				83474A6C2BED072A009B9C48 /* ToasterAPIService.swift in Sources */,
 				3F3ED29E2BA1A478004E79F0 /* TimerAPIService.swift in Sources */,
 				3F3ED29F2BA1A478004E79F0 /* GetTimerMainpageResponseDTO.swift in Sources */,
 				3F3ED2A02BA1A478004E79F0 /* TimerTargetType.swift in Sources */,
 				3F3ED2AA2BA1AAB7004E79F0 /* FontLiterals.swift in Sources */,
 				3F3ED2A62BA1A48F004E79F0 /* NoneDataResponseDTO.swift in Sources */,
+				83474A6B2BED06F1009B9C48 /* PatchEditLinkTitleRequestDTO.swift in Sources */,
 				3F3ED2A12BA1A478004E79F0 /* GetDetailTimerResponseDTO.swift in Sources */,
 				3F3ED2942BA1A45F004E79F0 /* GetMainPageResponseDTO.swift in Sources */,
 				3F3ED2B42BA1D5FF004E79F0 /* NSObject+.swift in Sources */,
@@ -1806,13 +1811,12 @@
 				3F3ED29B2BA1A475004E79F0 /* PatchEditTimerRequestDTO.swift in Sources */,
 				3F3ED29C2BA1A475004E79F0 /* PatchEditTimerTitleRequestDTO.swift in Sources */,
 				3F3ED29D2BA1A475004E79F0 /* PostCreateTimerRequestDTO.swift in Sources */,
-				3F3ED2982BA1A46E004E79F0 /* ToasterTargetType.swift in Sources */,
 				3F1F26262BAAC231004F75CE /* ShareViewController.swift in Sources */,
 				3F1F26222BAAB395004F75CE /* ToasterToastMessageView.swift in Sources */,
 				3F3ED2992BA1A46E004E79F0 /* PatchOpenLinkResponseDTO.swift in Sources */,
-				3F3ED29A2BA1A46E004E79F0 /* ToasterAPIService.swift in Sources */,
 				3F3ED2872BA1A400004E79F0 /* PostAddCategoryRequestDTO.swift in Sources */,
 				3F3ED2B52BA1D645004E79F0 /* ClipModel.swift in Sources */,
+				83474A6A2BED06EB009B9C48 /* ToasterTargetType.swift in Sources */,
 				3F3ED2952BA1A46B004E79F0 /* PatchOpenLinkRequestDTO.swift in Sources */,
 				3F3ED2A92BA1AAB4004E79F0 /* StringLiterals.swift in Sources */,
 				3F3ED2A22BA1A47E004E79F0 /* GetMainPageSearchResponseDTO.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TOASTER-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "8535921e89068b3e738cca6e484c870389c180e61e7044d1b3bbf9fb7a4df3ff",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -60,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
-        "version" : "7.12.1"
+        "revision" : "8e5d57ed87057cd7b0e4e8f474d9e78f73eb85f7",
+        "version" : "7.13.2"
       }
     },
     {
@@ -114,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
-        "version" : "1.22.3"
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -159,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
-        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
-        "version" : "6.6.0"
+        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
+        "version" : "6.7.1"
       }
     },
     {
@@ -191,5 +190,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/TOASTER-iOS.xcodeproj/xcshareddata/xcschemes/TOASTER-iOS.xcscheme
+++ b/TOASTER-iOS.xcodeproj/xcshareddata/xcschemes/TOASTER-iOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6B6AE64A2B3FF101000E2366"
+               BuildableName = "TOASTER-iOS.app"
+               BlueprintName = "TOASTER-iOS"
+               ReferencedContainer = "container:TOASTER-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6B6AE64A2B3FF101000E2366"
+            BuildableName = "TOASTER-iOS.app"
+            BlueprintName = "TOASTER-iOS"
+            ReferencedContainer = "container:TOASTER-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6B6AE64A2B3FF101000E2366"
+            BuildableName = "TOASTER-iOS.app"
+            BlueprintName = "TOASTER-iOS"
+            ReferencedContainer = "container:TOASTER-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TOASTER-iOS/Global/Consts/StringLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/StringLiterals.swift
@@ -31,6 +31,7 @@ enum StringLiterals {
         static let close = "닫기"
         static let cancel = "취소"
         static let next = "다음"
+        static let editTitle = "제목 편집"
     }
     
     enum Placeholder {

--- a/TOASTER-iOS/Global/Consts/StringLiterals.swift
+++ b/TOASTER-iOS/Global/Consts/StringLiterals.swift
@@ -51,6 +51,7 @@ enum StringLiterals {
         static let completeSetTimer = "타이머 설정 완료!"
         static let completeEditTimer = "타이머 수정 완료!"
         static let completeDeleteTimer = "타이머 삭제 완료"
+        static let completeEditTitle = "제목 편집 완료"
         static let noticeSetTimer = "한 클립당 하나의 타이머만 설정 가능해요"
         static let noticeMaxTimer = "타이머는 최대 다섯 개까지 설정 가능해요"
     }

--- a/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
+++ b/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct PatchEditLinkTitleRequestDTO: Codable {
     let toastId: Int
-    let newTitle: String
+    let title: String
 }

--- a/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
+++ b/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PatchEditLinkTitleRequestDTO.swift
+//  TOASTER-iOS
+//
+//  Created by Gahyun Kim on 2024/04/09.
+//
+
+import Foundation
+
+struct PatchEditLinkTitleRequestDTO: Codable {
+    let toastId: Int
+    let newTitle: String
+}

--- a/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
+++ b/TOASTER-iOS/Network/Toaster/DTO/Request/PatchEditLinkTitleRequestDTO.swift
@@ -2,7 +2,7 @@
 //  PatchEditLinkTitleRequestDTO.swift
 //  TOASTER-iOS
 //
-//  Created by Gahyun Kim on 2024/04/09.
+//  Created by Gahyun Kim on 2024/04/12.
 //
 
 import Foundation

--- a/TOASTER-iOS/Network/Toaster/DTO/Response/PatchEditLinkTitleResponseDTO.swift
+++ b/TOASTER-iOS/Network/Toaster/DTO/Response/PatchEditLinkTitleResponseDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PatchEditLinkTitleResponseDTO.swift
+//  TOASTER-iOS
+//
+//  Created by Gahyun Kim on 2024/05/05.
+//
+
+import Foundation
+
+struct PatchEditLinkTitleResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let data: PatchEditLinkTitleResponseData
+}
+
+struct PatchEditLinkTitleResponseData: Codable {
+    let updatedTitle: String
+}

--- a/TOASTER-iOS/Network/Toaster/ToasterAPIService.swift
+++ b/TOASTER-iOS/Network/Toaster/ToasterAPIService.swift
@@ -17,6 +17,8 @@ protocol ToasterAPIServiceProtocol {
     func deleteLink(toastId: Int,
                     completion: @escaping (NetworkResult<NoneDataResponseDTO>) -> Void)
     func getWeeksLink(completion: @escaping (NetworkResult<GetWeeksLinkResponseDTO>) -> Void)
+    func patchEditLinkTitle(requestBody: PatchEditLinkTitleRequestDTO,
+                            completion: @escaping (NetworkResult<PatchEditLinkTitleRequestDTO>) -> Void)
 }
 
 final class ToasterAPIService: BaseAPIService, ToasterAPIServiceProtocol {
@@ -84,6 +86,23 @@ final class ToasterAPIService: BaseAPIService, ToasterAPIServiceProtocol {
             case .failure(let error):
                 if let response = error.response {
                     let networkResult: NetworkResult<GetWeeksLinkResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    completion(networkResult)
+                }
+            }
+        }
+    }
+    
+    func patchEditLinkTitle(requestBody: PatchEditLinkTitleRequestDTO, 
+                            completion: @escaping (NetworkResult<PatchEditLinkTitleRequestDTO>) -> Void) {
+        provider.request(.patchEditLinkTitle(requestBody: requestBody)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<PatchEditLinkTitleRequestDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                print(networkResult.stateDescription)
+                completion(networkResult)
+            case .failure(let error):
+                if let response = error.response {
+                    let networkResult: NetworkResult<PatchEditLinkTitleRequestDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
                     completion(networkResult)
                 }
             }

--- a/TOASTER-iOS/Network/Toaster/ToasterAPIService.swift
+++ b/TOASTER-iOS/Network/Toaster/ToasterAPIService.swift
@@ -18,7 +18,7 @@ protocol ToasterAPIServiceProtocol {
                     completion: @escaping (NetworkResult<NoneDataResponseDTO>) -> Void)
     func getWeeksLink(completion: @escaping (NetworkResult<GetWeeksLinkResponseDTO>) -> Void)
     func patchEditLinkTitle(requestBody: PatchEditLinkTitleRequestDTO,
-                            completion: @escaping (NetworkResult<PatchEditLinkTitleRequestDTO>) -> Void)
+                            completion: @escaping (NetworkResult<PatchEditLinkTitleResponseDTO>) -> Void)
 }
 
 final class ToasterAPIService: BaseAPIService, ToasterAPIServiceProtocol {
@@ -93,16 +93,16 @@ final class ToasterAPIService: BaseAPIService, ToasterAPIServiceProtocol {
     }
     
     func patchEditLinkTitle(requestBody: PatchEditLinkTitleRequestDTO, 
-                            completion: @escaping (NetworkResult<PatchEditLinkTitleRequestDTO>) -> Void) {
+                            completion: @escaping (NetworkResult<PatchEditLinkTitleResponseDTO>) -> Void) {
         provider.request(.patchEditLinkTitle(requestBody: requestBody)) { result in
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<PatchEditLinkTitleRequestDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<PatchEditLinkTitleResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
                 print(networkResult.stateDescription)
                 completion(networkResult)
             case .failure(let error):
                 if let response = error.response {
-                    let networkResult: NetworkResult<PatchEditLinkTitleRequestDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    let networkResult: NetworkResult<PatchEditLinkTitleResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
                     completion(networkResult)
                 }
             }

--- a/TOASTER-iOS/Network/Toaster/ToasterTargetType.swift
+++ b/TOASTER-iOS/Network/Toaster/ToasterTargetType.swift
@@ -14,6 +14,7 @@ enum ToasterTargetType {
     case patchOpenLink(requestBody: PatchOpenLinkRequestDTO)
     case deleteLink(toastId: Int)
     case getWeeksLink
+    case patchEditLinkTitle(requestBody: PatchEditLinkTitleRequestDTO)
 }
 
 extension ToasterTargetType: BaseTargetType {
@@ -43,6 +44,7 @@ extension ToasterTargetType: BaseTargetType {
         case .patchOpenLink: return utilPath.rawValue + "/is-read"
         case .deleteLink: return utilPath.rawValue + "/delete"
         case .getWeeksLink: return utilPath.rawValue + "/week"
+        case .patchEditLinkTitle: return utilPath.rawValue + "/title"
         }
     }
     
@@ -52,6 +54,7 @@ extension ToasterTargetType: BaseTargetType {
         case .patchOpenLink: return .patch
         case .deleteLink: return .delete
         case .getWeeksLink: return .get
+        case .patchEditLinkTitle: return .patch
         }
     }
 }

--- a/TOASTER-iOS/Network/Toaster/ToasterTargetType.swift
+++ b/TOASTER-iOS/Network/Toaster/ToasterTargetType.swift
@@ -34,6 +34,7 @@ extension ToasterTargetType: BaseTargetType {
         switch self {
         case .postSaveLink(let body): return body
         case .patchOpenLink(let body): return body
+        case .patchEditLinkTitle(let body): return body
         default: return .none
         }
     }

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
@@ -22,6 +22,8 @@ final class DeleteLinkBottomSheetView: UIView {
     
     private let deleteButton = UIButton()
     private let editButton = UIButton()
+    private let deleteButtonLabel = UILabel()
+    private let editButtonLabel = UILabel()
     
     // MARK: - Life Cycles
     
@@ -61,40 +63,36 @@ extension DeleteLinkBottomSheetView {
 private extension DeleteLinkBottomSheetView {
     func setupStyle() {
         backgroundColor = .gray50
-        
+  
         editButton.do {
-            var configuration = UIButton.Configuration.filled()
-            configuration.baseBackgroundColor = .toasterWhite
-            configuration.baseForegroundColor = .black900
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0)
-            
-            var titleContainer = AttributeContainer()
-            titleContainer.font = UIFont.suitMedium(size: 16)
-            configuration.attributedTitle = AttributedString(StringLiterals.Button.editTitle, attributes: titleContainer)
-            
-            $0.configuration = configuration
+            $0.backgroundColor = .toasterWhite
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             $0.makeRounded(radius: 12)
-            $0.contentHorizontalAlignment = .leading
         }
         
         deleteButton.do {
-            var configuration = UIButton.Configuration.filled()
-            configuration.baseBackgroundColor = .toasterWhite
-            configuration.baseForegroundColor = .toasterPrimary
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0)
-            
-            var titleContainer = AttributeContainer()
-            titleContainer.font = UIFont.suitMedium(size: 16)
-            configuration.attributedTitle = AttributedString(StringLiterals.Button.delete, attributes: titleContainer)
-            
-            $0.configuration = configuration
+            $0.backgroundColor = .toasterWhite
+            $0.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             $0.makeRounded(radius: 12)
-            $0.contentHorizontalAlignment = .leading
+        }
+        
+        editButtonLabel.do {
+            $0.text = "수정하기"
+            $0.textColor = .black900
+            $0.font = .suitMedium(size: 16)
+        }
+        
+        deleteButtonLabel.do {
+            $0.text = StringLiterals.Button.delete
+            $0.textColor = .toasterError
+            $0.font = .suitMedium(size: 16)
         }
     }
     
     func setupHierarchy() {
         addSubviews(editButton, deleteButton)
+        editButton.addSubview(editButtonLabel)
+        deleteButton.addSubview(deleteButtonLabel)
     }
     
     func setupLayout() {
@@ -106,8 +104,15 @@ private extension DeleteLinkBottomSheetView {
         
         deleteButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.top.equalTo(editButton.snp.bottom).inset(5)
+            $0.top.equalTo(editButton.snp.bottom).offset(1)
             $0.height.equalTo(54)
+        }
+        
+        [editButtonLabel, deleteButtonLabel].forEach {
+            $0.snp.makeConstraints {
+                $0.centerY.equalToSuperview()
+                $0.leading.equalToSuperview().inset(20)
+            }
         }
     }
     

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
@@ -16,6 +16,7 @@ final class DeleteLinkBottomSheetView: UIView {
     
     private var deleteLinkBottomSheetViewButtonAction: (() -> Void)?
     private var editLinkTitleBottomSheetViewButtonAction: (() -> Void)?
+    private var confirmBottomSheetViewButtonAction: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -48,6 +49,10 @@ extension DeleteLinkBottomSheetView {
     
     func setupEditLinkTitleBottomSheetButtonAction(_ action: (() -> Void)?) {
         editLinkTitleBottomSheetViewButtonAction = action
+    }
+    
+    func setupConfirmBottomSheetButtonAction(_ action: (() -> Void)?) {
+        confirmBottomSheetViewButtonAction = action
     }
 }
 

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DeleteLinkBottomSheetView.swift
@@ -15,10 +15,12 @@ final class DeleteLinkBottomSheetView: UIView {
     // MARK: - Properties
     
     private var deleteLinkBottomSheetViewButtonAction: (() -> Void)?
+    private var editLinkTitleBottomSheetViewButtonAction: (() -> Void)?
     
     // MARK: - UI Components
     
     private let deleteButton = UIButton()
+    private let editButton = UIButton()
     
     // MARK: - Life Cycles
     
@@ -43,6 +45,10 @@ extension DeleteLinkBottomSheetView {
     func setupDeleteLinkBottomSheetButtonAction(_ action: (() -> Void)?) {
         deleteLinkBottomSheetViewButtonAction = action
     }
+    
+    func setupEditLinkTitleBottomSheetButtonAction(_ action: (() -> Void)?) {
+        editLinkTitleBottomSheetViewButtonAction = action
+    }
 }
 
 // MARK: - Private Extensions
@@ -50,6 +56,21 @@ extension DeleteLinkBottomSheetView {
 private extension DeleteLinkBottomSheetView {
     func setupStyle() {
         backgroundColor = .gray50
+        
+        editButton.do {
+            var configuration = UIButton.Configuration.filled()
+            configuration.baseBackgroundColor = .toasterWhite
+            configuration.baseForegroundColor = .black900
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0)
+            
+            var titleContainer = AttributeContainer()
+            titleContainer.font = UIFont.suitMedium(size: 16)
+            configuration.attributedTitle = AttributedString(StringLiterals.Button.editTitle, attributes: titleContainer)
+            
+            $0.configuration = configuration
+            $0.makeRounded(radius: 12)
+            $0.contentHorizontalAlignment = .leading
+        }
         
         deleteButton.do {
             var configuration = UIButton.Configuration.filled()
@@ -68,23 +89,37 @@ private extension DeleteLinkBottomSheetView {
     }
     
     func setupHierarchy() {
-        addSubviews(deleteButton)
+        addSubviews(editButton, deleteButton)
     }
     
     func setupLayout() {
-        deleteButton.snp.makeConstraints {
+        editButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.top.equalToSuperview()
+            $0.height.equalTo(54)
+        }
+        
+        deleteButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.top.equalTo(editButton.snp.bottom).inset(5)
             $0.height.equalTo(54)
         }
     }
     
     func setupAddTarget() {
+        editButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         deleteButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
     @objc
-    func buttonTapped() {
-        deleteLinkBottomSheetViewButtonAction?()
+    func buttonTapped(_ sender: UIButton) {
+        switch sender {
+        case editButton:
+            editLinkTitleBottomSheetViewButtonAction?()
+        case deleteButton:
+            deleteLinkBottomSheetViewButtonAction?()
+        default:
+            break
+        }
     }
 }

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheet.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheet.swift
@@ -1,0 +1,253 @@
+//
+//  DetailEditLinkBottomSheet.swift
+//  TOASTER-iOS
+//
+//  Created by Gahyun Kim on 2024/04/01.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+protocol EditLinkBottomSheetViewDelegate: AnyObject {
+    func dismissButtonTapped(title: String)
+    func addHeightBottom()
+    func minusHeightBottom()
+    func callCheckAPI(text: String)
+}
+
+final class EditLinkBottomSheetView: UIView {
+    
+    // MARK: - Properties
+    
+    weak var editLinkBottomSheetViewDelegate: EditLinkBottomSheetViewDelegate?
+    
+    private var isButtonClicked: Bool = false {
+        didSet {
+            setupButtonColor()
+        }
+    }
+    
+    private var isBorderColor: Bool = false {
+        didSet {
+            setupTextFieldBorder()
+        }
+    }
+    
+    private var isError: Bool = false {
+        didSet {
+            setupErrorMessage()
+        }
+    }
+    
+    private var isClearButtonShow: Bool = true {
+        didSet {
+            setupClearButton()
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private let addClipTextField = UITextField()
+    private let addClipButton = UIButton()
+    private let errorMessage = UILabel()
+    private let clearButton = UIButton()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setupKeyboard()
+    }
+}
+
+// MARK: - Private Extensions
+
+extension EditLinkBottomSheetView {
+    func resetTextField() {
+        addClipTextField.text = nil
+        addClipTextField.becomeFirstResponder()
+    }
+    
+    func changeTextField(addButton: Bool, border: Bool, error: Bool, clearButton: Bool) {
+        isButtonClicked = addButton
+        isBorderColor = border
+        isError = error
+        isClearButtonShow = clearButton
+    }
+    
+    func setupMessage(message: String) {
+        errorMessage.text = message
+    }
+    
+    func setupTextField(message: String) {
+        addClipTextField.text = message
+    }
+}
+
+// MARK: - Private Extensions
+
+private extension EditLinkBottomSheetView {
+    func setupStyle() {
+        backgroundColor = .toasterWhite
+        
+        addClipTextField.do {
+            $0.attributedPlaceholder = NSAttributedString(string: StringLiterals.Placeholder.addClip,
+                                                          attributes: [.foregroundColor: UIColor.gray400,
+                                                                       .font: UIFont.suitRegular(size: 16)])
+            $0.addPadding(left: 14, right: 44)
+            $0.backgroundColor = .gray50
+            $0.textColor = .black900
+            $0.makeRounded(radius: 12)
+            $0.borderStyle = .none
+            $0.isUserInteractionEnabled = true
+            $0.delegate = self
+        }
+        
+        addClipButton.do {
+            isButtonClicked = false
+            $0.setTitle(StringLiterals.Button.okay, for: .normal)
+            $0.setTitleColor(.toasterWhite, for: .normal)
+            $0.titleLabel?.font = .suitBold(size: 16)
+            $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        }
+        
+        errorMessage.do {
+            $0.isHidden = true
+            $0.font = .suitMedium(size: 12)
+            $0.textColor = .toasterError
+        }
+        
+        clearButton.do {
+            $0.isHidden = true
+            $0.setImage(.icSearchCancle, for: .normal)
+            $0.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
+        }
+    }
+    
+    func setupHierarchy() {
+        addSubviews(addClipTextField, addClipButton, errorMessage)
+        addClipTextField.addSubview(clearButton)
+    }
+    
+    func setupLayout() {
+        addClipTextField.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(54)
+        }
+        
+        errorMessage.snp.makeConstraints {
+            $0.top.equalTo(addClipTextField.snp.bottom).offset(6)
+            $0.leading.equalTo(addClipTextField)
+        }
+        
+        addClipButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(56)
+            $0.bottom.equalTo(keyboardLayoutGuide.snp.top)
+        }
+        
+        clearButton.snp.makeConstraints {
+            $0.size.equalTo(20)
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(12)
+        }
+    }
+    
+    func setupKeyboard() {
+        if !addClipTextField.isFirstResponder {
+            addClipTextField.becomeFirstResponder()
+        }
+    }
+    
+    func setupButtonColor() {
+        if isButtonClicked {
+            addClipButton.isEnabled = true
+            addClipButton.backgroundColor = .toasterPrimary
+        } else {
+            addClipButton.isEnabled = false
+            addClipButton.backgroundColor = .gray200
+        }
+    }
+    
+    func setupTextFieldBorder() {
+        if isBorderColor {
+            addClipTextField.layer.borderColor = UIColor.toasterError.cgColor
+            addClipTextField.layer.borderWidth = 1.0
+        } else {
+            addClipTextField.layer.borderColor = UIColor.clear.cgColor
+            addClipTextField.layer.borderWidth = 0.0
+        }
+    }
+    
+    func setupErrorMessage() {
+        if isError {
+            editLinkBottomSheetViewDelegate?.addHeightBottom()
+            errorMessage.isHidden = false
+        } else {
+            editLinkBottomSheetViewDelegate?.minusHeightBottom()
+            errorMessage.isHidden = true
+        }
+    }
+    
+    func setupClearButton() {
+        if isClearButtonShow {
+            clearButton.isHidden = false
+        } else {
+            clearButton.isHidden = true
+        }
+    }
+    
+    @objc
+    func buttonTapped() {
+        editLinkBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
+    }
+    
+    @objc
+    func clearButtonTapped() {
+        resetTextField()
+    }
+}
+
+// MARK: - UITextField Delegate
+
+extension EditLinkBottomSheetView: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let newText = (textField.text as NSString?)?.replacingCharacters(in: range, with: string) ?? string
+        let currentText = textField.text ?? ""
+        let maxLength = 16
+        
+        // 길이가 16에서 15로 돌아갈 때
+        if currentText.count == maxLength && newText.count == 15 {
+            editLinkBottomSheetViewDelegate?.minusHeightBottom()
+        }
+        return newText.count <= maxLength
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        let currentText = textField.text ?? ""
+        if currentText.isEmpty {
+            changeTextField(addButton: false, border: false, error: false, clearButton: false)
+        } else if currentText.count > 15 {
+            changeTextField(addButton: false, border: true, error: true, clearButton: true)
+            setupMessage(message: "클립의 이름은 최대 15자까지 입력 가능해요")
+        } else {
+            changeTextField(addButton: true, border: false, error: false, clearButton: true)
+        }
+    }
+}

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheet.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheet.swift
@@ -14,7 +14,7 @@ protocol EditLinkBottomSheetViewDelegate: AnyObject {
     func dismissButtonTapped(title: String)
     func addHeightBottom()
     func minusHeightBottom()
-    func callCheckAPI(text: String)
+    func callCheckAPI(filter: DetailCategoryFilter)
 }
 
 final class EditLinkBottomSheetView: UIView {

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheetView.swift
@@ -22,6 +22,7 @@ final class EditLinkBottomSheetView: UIView {
     // MARK: - Properties
     
     weak var editLinkBottomSheetViewDelegate: EditLinkBottomSheetViewDelegate?
+    private var confirmBottomSheetViewButtonAction: (() -> Void)?
     
     private var isButtonClicked: Bool = false {
         didSet {
@@ -50,7 +51,7 @@ final class EditLinkBottomSheetView: UIView {
     // MARK: - UI Components
     
     let addClipTextField = UITextField()
-    private let addClipButton = UIButton()
+    private let editClipButton = UIButton()
     private let errorMessage = UILabel()
     private let clearButton = UIButton()
     
@@ -75,7 +76,7 @@ final class EditLinkBottomSheetView: UIView {
     }
 }
 
-// MARK: - Private Extensions
+// MARK: - Extensions
 
 extension EditLinkBottomSheetView {
     func resetTextField() {
@@ -96,6 +97,10 @@ extension EditLinkBottomSheetView {
     
     func setupTextField(message: String) {
         addClipTextField.text = message
+    }
+    
+    func setupConfirmBottomSheetButtonAction(_ action: (() -> Void)?) {
+        confirmBottomSheetViewButtonAction = action
     }
 }
 
@@ -118,7 +123,7 @@ private extension EditLinkBottomSheetView {
             $0.delegate = self
         }
         
-        addClipButton.do {
+        editClipButton.do {
             isButtonClicked = false
             $0.setTitle(StringLiterals.Button.okay, for: .normal)
             $0.setTitleColor(.toasterWhite, for: .normal)
@@ -140,7 +145,7 @@ private extension EditLinkBottomSheetView {
     }
     
     func setupHierarchy() {
-        addSubviews(addClipTextField, addClipButton, errorMessage)
+        addSubviews(addClipTextField, editClipButton, errorMessage)
         addClipTextField.addSubview(clearButton)
     }
     
@@ -156,7 +161,7 @@ private extension EditLinkBottomSheetView {
             $0.leading.equalTo(addClipTextField)
         }
         
-        addClipButton.snp.makeConstraints {
+        editClipButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(56)
             $0.bottom.equalTo(keyboardLayoutGuide.snp.top)
@@ -177,11 +182,11 @@ private extension EditLinkBottomSheetView {
     
     func setupButtonColor() {
         if isButtonClicked {
-            addClipButton.isEnabled = true
-            addClipButton.backgroundColor = .toasterPrimary
+            editClipButton.isEnabled = true
+            editClipButton.backgroundColor = .toasterPrimary
         } else {
-            addClipButton.isEnabled = false
-            addClipButton.backgroundColor = .gray200
+            editClipButton.isEnabled = false
+            editClipButton.backgroundColor = .gray200
         }
     }
     
@@ -215,6 +220,7 @@ private extension EditLinkBottomSheetView {
     
     @objc
     func buttonTapped() {
+        confirmBottomSheetViewButtonAction?()
         editLinkBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
     }
     
@@ -245,7 +251,7 @@ extension EditLinkBottomSheetView: UITextFieldDelegate {
             changeTextField(addButton: false, border: false, error: false, clearButton: false)
         } else if currentText.count > 15 {
             changeTextField(addButton: false, border: true, error: true, clearButton: true)
-            setupMessage(message: "클립의 이름은 최대 15자까지 입력 가능해요")
+            setupMessage(message: "링크 제목은 최대 15자까지 입력 가능해요")
         } else {
             changeTextField(addButton: true, border: false, error: false, clearButton: true)
         }

--- a/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/DetailEditLinkBottomSheetView.swift
@@ -1,0 +1,253 @@
+//
+//  DetailEditLinkBottomSheetView.swift
+//  TOASTER-iOS
+//
+//  Created by Gahyun Kim on 2024/04/12.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+protocol EditLinkBottomSheetViewDelegate: AnyObject {
+    func dismissButtonTapped(title: String)
+    func addHeightBottom()
+    func minusHeightBottom()
+    func callCheckAPI(filter: DetailCategoryFilter)
+}
+
+final class EditLinkBottomSheetView: UIView {
+    
+    // MARK: - Properties
+    
+    weak var editLinkBottomSheetViewDelegate: EditLinkBottomSheetViewDelegate?
+    
+    private var isButtonClicked: Bool = false {
+        didSet {
+            setupButtonColor()
+        }
+    }
+    
+    private var isBorderColor: Bool = false {
+        didSet {
+            setupTextFieldBorder()
+        }
+    }
+    
+    private var isError: Bool = false {
+        didSet {
+            setupErrorMessage()
+        }
+    }
+    
+    private var isClearButtonShow: Bool = true {
+        didSet {
+            setupClearButton()
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    let addClipTextField = UITextField()
+    private let addClipButton = UIButton()
+    private let errorMessage = UILabel()
+    private let clearButton = UIButton()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setupKeyboard()
+    }
+}
+
+// MARK: - Private Extensions
+
+extension EditLinkBottomSheetView {
+    func resetTextField() {
+        addClipTextField.text = nil
+        addClipTextField.becomeFirstResponder()
+    }
+    
+    func changeTextField(addButton: Bool, border: Bool, error: Bool, clearButton: Bool) {
+        isButtonClicked = addButton
+        isBorderColor = border
+        isError = error
+        isClearButtonShow = clearButton
+    }
+    
+    func setupMessage(message: String) {
+        errorMessage.text = message
+    }
+    
+    func setupTextField(message: String) {
+        addClipTextField.text = message
+    }
+}
+
+// MARK: - Private Extensions
+
+private extension EditLinkBottomSheetView {
+    func setupStyle() {
+        backgroundColor = .toasterWhite
+        
+        addClipTextField.do {
+            $0.attributedPlaceholder = NSAttributedString(string: StringLiterals.Placeholder.addClip,
+                                                          attributes: [.foregroundColor: UIColor.gray400,
+                                                                       .font: UIFont.suitRegular(size: 16)])
+            $0.addPadding(left: 14, right: 44)
+            $0.backgroundColor = .gray50
+            $0.textColor = .black900
+            $0.makeRounded(radius: 12)
+            $0.borderStyle = .none
+            $0.isUserInteractionEnabled = true
+            $0.delegate = self
+        }
+        
+        addClipButton.do {
+            isButtonClicked = false
+            $0.setTitle(StringLiterals.Button.okay, for: .normal)
+            $0.setTitleColor(.toasterWhite, for: .normal)
+            $0.titleLabel?.font = .suitBold(size: 16)
+            $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        }
+        
+        errorMessage.do {
+            $0.isHidden = true
+            $0.font = .suitMedium(size: 12)
+            $0.textColor = .toasterError
+        }
+        
+        clearButton.do {
+            $0.isHidden = true
+            $0.setImage(.icSearchCancle, for: .normal)
+            $0.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
+        }
+    }
+    
+    func setupHierarchy() {
+        addSubviews(addClipTextField, addClipButton, errorMessage)
+        addClipTextField.addSubview(clearButton)
+    }
+    
+    func setupLayout() {
+        addClipTextField.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(54)
+        }
+        
+        errorMessage.snp.makeConstraints {
+            $0.top.equalTo(addClipTextField.snp.bottom).offset(6)
+            $0.leading.equalTo(addClipTextField)
+        }
+        
+        addClipButton.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(56)
+            $0.bottom.equalTo(keyboardLayoutGuide.snp.top)
+        }
+        
+        clearButton.snp.makeConstraints {
+            $0.size.equalTo(20)
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(12)
+        }
+    }
+    
+    func setupKeyboard() {
+        if !addClipTextField.isFirstResponder {
+            addClipTextField.becomeFirstResponder()
+        }
+    }
+    
+    func setupButtonColor() {
+        if isButtonClicked {
+            addClipButton.isEnabled = true
+            addClipButton.backgroundColor = .toasterPrimary
+        } else {
+            addClipButton.isEnabled = false
+            addClipButton.backgroundColor = .gray200
+        }
+    }
+    
+    func setupTextFieldBorder() {
+        if isBorderColor {
+            addClipTextField.layer.borderColor = UIColor.toasterError.cgColor
+            addClipTextField.layer.borderWidth = 1.0
+        } else {
+            addClipTextField.layer.borderColor = UIColor.clear.cgColor
+            addClipTextField.layer.borderWidth = 0.0
+        }
+    }
+    
+    func setupErrorMessage() {
+        if isError {
+            editLinkBottomSheetViewDelegate?.addHeightBottom()
+            errorMessage.isHidden = false
+        } else {
+            editLinkBottomSheetViewDelegate?.minusHeightBottom()
+            errorMessage.isHidden = true
+        }
+    }
+    
+    func setupClearButton() {
+        if isClearButtonShow {
+            clearButton.isHidden = false
+        } else {
+            clearButton.isHidden = true
+        }
+    }
+    
+    @objc
+    func buttonTapped() {
+        editLinkBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
+    }
+    
+    @objc
+    func clearButtonTapped() {
+        resetTextField()
+    }
+}
+
+// MARK: - UITextField Delegate
+
+extension EditLinkBottomSheetView: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let newText = (textField.text as NSString?)?.replacingCharacters(in: range, with: string) ?? string
+        let currentText = textField.text ?? ""
+        let maxLength = 16
+        
+        // 길이가 16에서 15로 돌아갈 때
+        if currentText.count == maxLength && newText.count == 15 {
+            editLinkBottomSheetViewDelegate?.minusHeightBottom()
+        }
+        return newText.count <= maxLength
+    }
+    
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        let currentText = textField.text ?? ""
+        if currentText.isEmpty {
+            changeTextField(addButton: false, border: false, error: false, clearButton: false)
+        } else if currentText.count > 15 {
+            changeTextField(addButton: false, border: true, error: true, clearButton: true)
+            setupMessage(message: "클립의 이름은 최대 15자까지 입력 가능해요")
+        } else {
+            changeTextField(addButton: true, border: false, error: false, clearButton: true)
+        }
+    }
+}

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -122,7 +122,6 @@ private extension DetailClipViewController {
     }
     
     func editLinkTitleAction() {
-        showToastMessage(width: 157, status: .check, message: StringLiterals.ToastMessage.completeEditClip)
         editLinkBottomSheetView.resetTextField()
     }
     

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -19,7 +19,7 @@ final class DetailClipViewController: UIViewController {
     private let detailClipListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
     private let deleteLinkBottomSheetView = DeleteLinkBottomSheetView()
-    private lazy var bottom = ToasterBottomSheetViewController(bottomType: .gray, bottomTitle: "수정하기", height: 72, insertView: deleteLinkBottomSheetView)
+    private lazy var bottom = ToasterBottomSheetViewController(bottomType: .gray, bottomTitle: "수정하기", height: 126, insertView: deleteLinkBottomSheetView)
     
     // MARK: - Life Cycle
     

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -160,7 +160,8 @@ extension DetailClipViewController: UICollectionViewDataSource {
             }
         }
         deleteLinkBottomSheetView.setupEditLinkTitleBottomSheetButtonAction {
-            //self.viewModel.patchEditLinkTitleAPI(toastId: self.viewModel.toastId, title: editLinkBottomSheetView.)
+            self.viewModel.patchEditLinkTitleAPI(toastId: self.viewModel.toastId,
+                                                 title: self.viewModel.linkTitle)
             print("🎃", self.viewModel.toastList)
             self.bottom.hideBottomSheet()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -264,5 +265,27 @@ extension DetailClipViewController: DetailClipListCollectionViewCellDelegate {
         viewModel.toastId = toastId
         bottom.modalPresentationStyle = .overFullScreen
         present(bottom, animated: false)
+    }
+}
+
+// MARK: - AddClipBottomSheetView Delegate
+
+extension DetailClipViewController: EditLinkBottomSheetViewDelegate {
+    func callCheckAPI(filter: DetailCategoryFilter) {
+        viewModel.getDetailAllCategoryAPI(filter: filter)
+    }
+    
+    func addHeightBottom() {
+        editLinkBottom.changeHeightBottomSheet(height: 219)
+    }
+    
+    func minusHeightBottom() {
+        editLinkBottom.changeHeightBottomSheet(height: 198)
+    }
+    
+    func dismissButtonTapped(title: String) {
+        editLinkBottom.hideBottomSheet()
+        viewModel.patchEditLinkTitleAPI(toastId: viewModel.toastId,
+                                        title: title)
     }
 }

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -160,9 +160,8 @@ extension DetailClipViewController: UICollectionViewDataSource {
             }
         }
         deleteLinkBottomSheetView.setupEditLinkTitleBottomSheetButtonAction {
-            self.viewModel.patchEditLinkTitleAPI(toastId: self.viewModel.toastId,
-                                                 title: self.viewModel.linkTitle)
-            print("🎃", self.viewModel.toastList)
+            self.viewModel.getDetailCategoryAPI(categoryID: self.viewModel.categoryId,
+                                                filter: DetailCategoryFilter.all)
             self.bottom.hideBottomSheet()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.editLinkBottom.modalPresentationStyle = .overFullScreen
@@ -268,7 +267,7 @@ extension DetailClipViewController: DetailClipListCollectionViewCellDelegate {
     }
 }
 
-// MARK: - AddClipBottomSheetView Delegate
+// MARK: - EditLinkBottomSheetView Delegate
 
 extension DetailClipViewController: EditLinkBottomSheetViewDelegate {
     func callCheckAPI(filter: DetailCategoryFilter) {

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -19,7 +19,16 @@ final class DetailClipViewController: UIViewController {
     private let detailClipListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
     private let deleteLinkBottomSheetView = DeleteLinkBottomSheetView()
-    private lazy var bottom = ToasterBottomSheetViewController(bottomType: .gray, bottomTitle: "수정하기", height: 126, insertView: deleteLinkBottomSheetView)
+    private lazy var bottom = ToasterBottomSheetViewController(bottomType: .gray, 
+                                                               bottomTitle: "수정하기",
+                                                               height: 126,
+                                                               insertView: deleteLinkBottomSheetView)
+    
+    private let editLinkBottomSheetView = EditLinkBottomSheetView()
+    private lazy var editLinkBottom = ToasterBottomSheetViewController(bottomType: .white,
+                                                                       bottomTitle: "링크 제목 편집",
+                                                                       height: 198,
+                                                                       insertView: editLinkBottomSheetView)
     
     // MARK: - Life Cycle
     
@@ -58,10 +67,14 @@ private extension DetailClipViewController {
         view.backgroundColor = .toasterBackground
         detailClipListCollectionView.backgroundColor = .toasterBackground
         detailClipEmptyView.isHidden = false
+        editLinkBottomSheetView.editLinkBottomSheetViewDelegate = self
+        
     }
     
     func setupHierarchy() {
-        view.addSubviews(detailClipSegmentedControlView, detailClipListCollectionView, detailClipEmptyView)
+        view.addSubviews(detailClipSegmentedControlView, 
+                         detailClipListCollectionView,
+                         detailClipEmptyView)
     }
     
     func setupLayout() {
@@ -94,7 +107,8 @@ private extension DetailClipViewController {
     
     func setupViewModel() {
         viewModel.setupDataChangeAction(changeAction: reloadCollectionView,
-                                        forUnAuthorizedAction: unAuthorizedAction)
+                                        forUnAuthorizedAction: unAuthorizedAction,
+                                        editNameAction: editLinkTitleAction)
     }
     
     func reloadCollectionView(isHidden: Bool) {
@@ -104,6 +118,11 @@ private extension DetailClipViewController {
     
     func unAuthorizedAction() {
         changeViewController(viewController: LoginViewController())
+    }
+    
+    func editLinkTitleAction() {
+        showToastMessage(width: 157, status: .check, message: StringLiterals.ToastMessage.completeEditClip)
+        editLinkBottomSheetView.resetTextField()
     }
     
     func setupNavigationBar() {
@@ -138,6 +157,16 @@ extension DetailClipViewController: UICollectionViewDataSource {
             self.bottom.hideBottomSheet()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 self.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeDeleteLink)
+            }
+        }
+        deleteLinkBottomSheetView.setupEditLinkTitleBottomSheetButtonAction {
+            //self.viewModel.patchEditLinkTitleAPI(toastId: self.viewModel.toastId, title: editLinkBottomSheetView.)
+            print("🎃", self.viewModel.toastList)
+            self.bottom.hideBottomSheet()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.editLinkBottom.modalPresentationStyle = .overFullScreen
+                self.present(self.editLinkBottom, animated: true)
+                self.editLinkBottomSheetView.setupTextField(message: self.viewModel.linkTitle)
             }
         }
         return cell

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -169,6 +169,14 @@ extension DetailClipViewController: UICollectionViewDataSource {
                 self.editLinkBottomSheetView.setupTextField(message: self.viewModel.linkTitle)
             }
         }
+        editLinkBottomSheetView.setupConfirmBottomSheetButtonAction {
+            self.viewModel.getDetailCategoryAPI(categoryID: self.viewModel.categoryId,
+                                                filter: DetailCategoryFilter.all)
+            self.bottom.hideBottomSheet()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                self.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeEditTitle)
+            }
+        }
         return cell
     }
     

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipPropertyType.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipPropertyType.swift
@@ -12,4 +12,5 @@ enum DetailClipPropertyType {
     case categoryId
     case categoryName
     case segmentIndex
+    case linkTitle
 }

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
@@ -139,24 +139,6 @@ extension DetailClipViewModel {
         }
     }
     
-//    func patchEditLinkTitleAPI(requestBody: DetailClipModel) {
-//        NetworkService.shared.toastService.patchEditLinkTitle(
-//            requestBody: PatchEditLinkTitleRequestDTO(
-//                toastId: requestBody.toastList[0].id,
-//                newTitle: requestBody.toastList[0].title)) { result in
-//            switch result {
-//            case .success:
-//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-//                    self.editLinkTitleAction?()
-//                }
-//                self.getDetailAllCategoryAPI(filter: .all)
-//            case .unAuthorized, .networkFail, .notFound:
-//                self.unAuthorizedAction?()
-//            default: return
-//            }
-//        }
-//    }
-    
     func patchEditLinkTitleAPI(toastId: Int, title: String) {
         NetworkService.shared.toastService.patchEditLinkTitle(
             requestBody: PatchEditLinkTitleRequestDTO(

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
@@ -16,6 +16,7 @@ final class DetailClipViewModel: NSObject {
     
     typealias NormalChangeAction = () -> Void
     private var unAuthorizedAction: NormalChangeAction?
+    private var editLinkTitleAction: NormalChangeAction?
     
     // MARK: - Data
     
@@ -23,6 +24,7 @@ final class DetailClipViewModel: NSObject {
     var categoryId: Int = 0
     var categoryName: String = ""
     var segmentIndex: Int = 0
+    var linkTitle: String = ""
     
     private(set) var toastList: DetailClipModel = DetailClipModel(allToastCount: 0, toastList: []) {
         didSet {
@@ -35,9 +37,11 @@ final class DetailClipViewModel: NSObject {
 
 extension DetailClipViewModel {
     func setupDataChangeAction(changeAction: @escaping DataChangeAction,
-                               forUnAuthorizedAction: @escaping NormalChangeAction) {
+                               forUnAuthorizedAction: @escaping NormalChangeAction,
+                               editNameAction: @escaping NormalChangeAction) {
         dataChangeAction = changeAction
         unAuthorizedAction = forUnAuthorizedAction
+        editLinkTitleAction = editNameAction
     }
     
     func getViewModelProperty(dataType: DetailClipPropertyType) -> Any {
@@ -50,6 +54,8 @@ extension DetailClipViewModel {
             return categoryName
         case .segmentIndex:
             return segmentIndex
+        case .linkTitle:
+            return linkTitle
         }
     }
     
@@ -114,6 +120,42 @@ extension DetailClipViewModel {
                     default: self.getDetailCategoryAPI(categoryID: self.categoryId, filter: .unread)
                     }
                 }
+            case .unAuthorized, .networkFail, .notFound:
+                self.unAuthorizedAction?()
+            default: return
+            }
+        }
+    }
+    
+//    func patchEditLinkTitleAPI(requestBody: DetailClipModel) {
+//        NetworkService.shared.toastService.patchEditLinkTitle(
+//            requestBody: PatchEditLinkTitleRequestDTO(
+//                toastId: requestBody.toastList[0].id,
+//                newTitle: requestBody.toastList[0].title)) { result in
+//            switch result {
+//            case .success:
+//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+//                    self.editLinkTitleAction?()
+//                }
+//                self.getDetailAllCategoryAPI(filter: .all)
+//            case .unAuthorized, .networkFail, .notFound:
+//                self.unAuthorizedAction?()
+//            default: return
+//            }
+//        }
+//    }
+    
+    func patchEditLinkTitleAPI(toastId: Int, title: String) {
+        NetworkService.shared.toastService.patchEditLinkTitle(
+            requestBody: PatchEditLinkTitleRequestDTO(
+                toastId: toastId,
+                title: title)) { result in
+            switch result {
+            case .success:
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.editLinkTitleAction?()
+                }
+                self.getDetailAllCategoryAPI(filter: .all)
             case .unAuthorized, .networkFail, .notFound:
                 self.unAuthorizedAction?()
             default: return

--- a/TOASTER-iOS/TOASTER-iOS.entitlements
+++ b/TOASTER-iOS/TOASTER-iOS.entitlements
@@ -9,9 +9,7 @@
 		<string>Default</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.TeamLinkMIND.TOASTER-iOS</string>
-	</array>
+	<array/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)group.TeamLinkMIND.TOASTER-iOS.KeyChain</string>

--- a/ToasterShareExtension/ShareViewController.swift
+++ b/ToasterShareExtension/ShareViewController.swift
@@ -13,7 +13,7 @@ import Then
 
 @objc(ShareViewController)
 class ShareViewController: UIViewController {
-
+    
     // MARK: - Properties
     private var urlString = ""
     private let viewModel = RemindSelectClipViewModel()
@@ -30,7 +30,7 @@ class ShareViewController: UIViewController {
     
     private let appURL = "TOASTER://"
     private var isUseShareExtension = false
-
+    
     // MARK: - UI Components
     
     private let titleLabel = UILabel()
@@ -79,7 +79,7 @@ class ShareViewController: UIViewController {
                 $0.height.equalTo(bottomSheetHeight())
                 $0.bottom.leading.trailing.equalToSuperview()
             }
-
+            
             DispatchQueue.main.async {
                 UIView.animate(withDuration: 0.15, delay: 0, options: .curveEaseInOut, animations: {
                     self.view.layoutIfNeeded()
@@ -198,14 +198,14 @@ private extension ShareViewController {
     // 웹 사이트 URL 를 받아올 수 있는 메서드
     func getUrl() {
         if let item = extensionContext?.inputItems.first as? NSExtensionItem,
-            let itemProvider = item.attachments?.first as? NSItemProvider,
-            itemProvider.hasItemConformingToTypeIdentifier("public.url") {
+           let itemProvider = item.attachments?.first as? NSItemProvider,
+           itemProvider.hasItemConformingToTypeIdentifier("public.url") {
             itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil) { [weak self] (url, error) in
                 if let shareURL = url as? URL {
                     self?.urlString = shareURL.absoluteString
-               } else {
-                   print("Error loading URL: \(error?.localizedDescription ?? "")")
-               }
+                } else {
+                    print("Error loading URL: \(error?.localizedDescription ?? "")")
+                }
             }
         }
     }
@@ -292,7 +292,8 @@ private extension ShareViewController {
 extension ShareViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         selectedClip = viewModel.clipData[indexPath.item]
-        categoryID = viewModel.clipData[indexPath.item].id
+        let selectRow = viewModel.clipData[indexPath.item].id
+        categoryID = selectRow == 0 ? nil : selectRow
     }
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #179 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | ![iPhone 14](https://github.com/Link-MIND/TOASTER-iOS/assets/101050833/36a1cfae-597c-44f6-871b-32ff01a8e054) | ![iPhone 13 mini](https://github.com/Link-MIND/TOASTER-iOS/assets/101050833/e68314ed-c60c-4148-8837-77a1af0c860d) | ![iPhone 15 Pro](https://github.com/Link-MIND/TOASTER-iOS/assets/101050833/2adaf2b2-b2a7-42d8-ae09-4aae145a79c5) |



## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`DetailClipViewController`
- 이중 바텀시트를 순차적으로 내린 후 토스트메세지를 띄웠습니다. 
```swift
func dismissButtonTapped(title: String) {
        viewModel.patchEditLinkTitleAPI(toastId: viewModel.toastId,
                                        title: title)
        // 이중 바텀시트 순차적으로 내리기
        editLinkBottom.hideBottomSheet()
        editBottom.hideBottomSheet()
        
        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
            guard let self else { return }
            self.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeEditTitle)
        }
    }
```


`DetailClipViewController`
- 제목 변경 후 실시간으로 cell에 반영한 코드입니다. 
```swift
extension DetailClipViewController: PatchClipDelegate {
    func patchEnd() {
        viewModel.getDetailCategoryAPI(categoryID: self.viewModel.categoryId,
                                       filter: DetailCategoryFilter.all) {
            self.detailClipListCollectionView.reloadData()
        }
    }
}
```

## 📂 참고한 내용
<!-- 참고한 사이트나 정보가 있다면 작성주세요 -->
- 혁님과...민재오빠와...다예언니입니다 


## ✅ Checklist
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
