### PR TITLE
[Feat] #193 - Sheet UISheetPresentationController로 로직 변경

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -276,7 +276,7 @@
 		83474A6D2BED0750009B9C48 /* PatchEditLinkTitleResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */; };
 		8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */; };
 		8388E98C2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */; };
-		8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */; };
+		8388E98E2BC8FC6700858C5C /* EditLinkBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8388E98D2BC8FC6700858C5C /* EditLinkBottomSheetView.swift */; };
 		83CFC3372B564F1100A2EB2B /* WeeklyLinkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */; };
 		83CFC3392B568BE700A2EB2B /* RecommendSiteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC3382B568BE700A2EB2B /* RecommendSiteModel.swift */; };
 		83CFC33B2B57324700A2EB2B /* SaveLinkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CFC33A2B57324700A2EB2B /* SaveLinkModel.swift */; };
@@ -487,7 +487,7 @@
 		8315CD902B5521F70061F377 /* SelectClipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectClipModel.swift; sourceTree = "<group>"; };
 		8364220B2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditLinkTitleResponseDTO.swift; sourceTree = "<group>"; };
 		8388E98B2BC8FAB200858C5C /* PatchEditLinkTitleRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditLinkTitleRequestDTO.swift; sourceTree = "<group>"; };
-		8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailEditLinkBottomSheetView.swift; sourceTree = "<group>"; };
+		8388E98D2BC8FC6700858C5C /* EditLinkBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLinkBottomSheetView.swift; sourceTree = "<group>"; };
 		83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyLinkModel.swift; sourceTree = "<group>"; };
 		83CFC3382B568BE700A2EB2B /* RecommendSiteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendSiteModel.swift; sourceTree = "<group>"; };
 		83CFC33A2B57324700A2EB2B /* SaveLinkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveLinkModel.swift; sourceTree = "<group>"; };
@@ -679,7 +679,7 @@
 				39BE4BBD2B4ABB7C002B471D /* DetailClipSegmentedControlView.swift */,
 				39BE4BBF2B4ABB9E002B471D /* DetailClipEmptyView.swift */,
 				39BE4BC12B4ABBB0002B471D /* DeleteLinkBottomSheetView.swift */,
-				8388E98D2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift */,
+				8388E98D2BC8FC6700858C5C /* EditLinkBottomSheetView.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -1948,7 +1948,7 @@
 				6BE6DA9C2B54752B008B06FA /* GetTimerMainpageResponseDTO.swift in Sources */,
 				6B6AE6AA2B3FF6EA000E2366 /* UIStackView+.swift in Sources */,
 				8305178A2B4D1E09009FFB60 /* UserClipCollectionViewCell.swift in Sources */,
-				8388E98E2BC8FC6700858C5C /* DetailEditLinkBottomSheetView.swift in Sources */,
+				8388E98E2BC8FC6700858C5C /* EditLinkBottomSheetView.swift in Sources */,
 				3913B0AE2BCEC9C00031A3EB /* UpdateAlertManager.swift in Sources */,
 				3F2FA17D2B4928B700EDBF95 /* LoginUseCase.swift in Sources */,
 				6BE6DA9A2B54747B008B06FA /* TimerAPIService.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -2226,7 +2226,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2261,7 +2261,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TOASTER-iOS/Global/Components/ToasterBottomSheet/ToasterBottomSheetViewController.swift
+++ b/TOASTER-iOS/Global/Components/ToasterBottomSheet/ToasterBottomSheetViewController.swift
@@ -12,15 +12,9 @@ import Then
 
 final class ToasterBottomSheetViewController: UIViewController {
     
-    // MARK: - Properties
-    
-    private var bottomHeight: CGFloat = 100
-    private var keyboardHeight: CGFloat = 100
-    
     // MARK: - UI Properties
-    private var insertView = UIView()
-    private let dimmedBackView = UIView()
-    private let bottomSheetView = UIView()
+    
+    private var insertView: UIView
     
     private let titleLabel = UILabel()
     private let closeButton = UIButton()
@@ -29,15 +23,10 @@ final class ToasterBottomSheetViewController: UIViewController {
     
     init(bottomType: BottomType,
          bottomTitle: String,
-         height: CGFloat,
          insertView: UIView) {
-        super.init(nibName: nil, bundle: nil)
-        
-        self.bottomSheetView.backgroundColor = bottomType.color
-        self.titleLabel.textAlignment = bottomType.alignment
-        self.titleLabel.text = bottomTitle
-        self.bottomHeight = height
         self.insertView = insertView
+        super.init(nibName: nil, bundle: nil)
+        setupInitialStyle(bottomType: bottomType, bottomTitle: bottomTitle)
     }
     
     required init?(coder: NSCoder) {
@@ -46,64 +35,29 @@ final class ToasterBottomSheetViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         setupStyle()
         setupHierarchy()
         setupLayout()
-        setupDismissAction()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        showBottomSheet()
     }
 }
 
-// MARK: - Networks
-
-@MainActor
 extension ToasterBottomSheetViewController {
-    /// 바텀 시트 표출
-    func showBottomSheet() {
-        Task {
-            self.updateBottomSheetLayout()
-            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut, animations: {
-                self.dimmedBackView.backgroundColor = .black900.withAlphaComponent(0.5)
-                self.view.layoutIfNeeded()
-            })
+    func setupSheetPresentation(bottomHeight: CGFloat) {
+        if let sheet = self.sheetPresentationController {
+            if #available(iOS 16.0, *) {
+                sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
+            }
+            sheet.preferredCornerRadius = 20
         }
     }
     
-    /// 바텀 시트 내리기
-    func hideBottomSheet() {
-        Task {
-            self.bottomSheetView.snp.remakeConstraints {
-                $0.bottom.leading.trailing.equalToSuperview()
-            }
-            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut, animations: {
-                self.dimmedBackView.backgroundColor = .clear
-                self.view.layoutIfNeeded()
-                self.view.endEditing(true)
-            }, completion: { _ in
-                if self.presentingViewController != nil {
-                    self.dismiss(animated: false, completion: nil)
+    func setupSheetHeightChanges(bottomHeight: CGFloat) {
+        if let sheet = self.sheetPresentationController {
+            sheet.animateChanges {
+                if #available(iOS 16.0, *) {
+                    sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
                 }
-            })
-        }
-    }
-    
-    /// 바텀 시트 올라와있는 상태에서 높이 변화 시키기
-    func changeHeightBottomSheet(height: CGFloat) {
-        Task {
-            self.bottomSheetView.snp.remakeConstraints {
-                $0.bottom.leading.trailing.equalToSuperview()
-                $0.top.equalToSuperview().inset(self.view.frame.height - self.keyboardHeight - height)
             }
-            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseInOut, animations: {
-                self.dimmedBackView.backgroundColor = .black900.withAlphaComponent(0.5)
-                self.view.layoutIfNeeded()
-            })
         }
     }
 }
@@ -111,17 +65,13 @@ extension ToasterBottomSheetViewController {
 // MARK: - Private Extensions
 
 private extension ToasterBottomSheetViewController {
+    func setupInitialStyle(bottomType: BottomType, bottomTitle: String) {
+        self.view.backgroundColor = bottomType.color
+        self.titleLabel.textAlignment = bottomType.alignment
+        self.titleLabel.text = bottomTitle
+    }
     
     func setupStyle() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-        
-        bottomSheetView.do {
-            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            $0.makeRounded(radius: 20)
-        }
-        
         titleLabel.do {
             $0.font = .suitBold(size: 18)
             $0.textColor = .toasterBlack
@@ -129,23 +79,18 @@ private extension ToasterBottomSheetViewController {
         
         closeButton.do {
             $0.setImage(.icClose24, for: .normal)
+            $0.addAction(
+                UIAction { [weak self] _ in self?.dismiss(animated: true) },
+                for: .touchUpInside
+            )
         }
     }
     
     func setupHierarchy() {
-        view.addSubviews(dimmedBackView, bottomSheetView)
-        bottomSheetView.addSubviews(titleLabel, closeButton, insertView)
+        view.addSubviews(titleLabel, closeButton, insertView)
     }
     
     func setupLayout() {
-        dimmedBackView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        bottomSheetView.snp.makeConstraints {
-            $0.leading.trailing.bottom.equalToSuperview()
-        }
-        
         insertView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.top.equalToSuperview().inset(64)
@@ -158,48 +103,5 @@ private extension ToasterBottomSheetViewController {
         closeButton.snp.makeConstraints {
             $0.top.trailing.equalToSuperview().inset(20)
         }
-    }
-    
-    func setupDismissAction() {
-        // x 버튼 누를 때, 바텀시트를 내리는 Action Target
-        closeButton.addTarget(self, action: #selector(hideBottomSheetAction), for: .touchUpInside)
-        
-        // 흐린 부분 탭할 때, 바텀시트를 내리는 TapGesture
-        let dimmedTap = UITapGestureRecognizer(target: self, action: #selector(hideBottomSheetAction))
-        dimmedBackView.addGestureRecognizer(dimmedTap)
-        dimmedBackView.isUserInteractionEnabled = true
-        
-        // 아래로 스와이프 했을 때, 바텀시트를 내리는 swipeGesture
-        let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(hideBottomSheetAction))
-        swipeGesture.direction = .down
-        view.addGestureRecognizer(swipeGesture)
-    }
-    
-    func updateBottomSheetLayout() {
-        bottomSheetView.snp.remakeConstraints {
-            $0.bottom.leading.trailing.equalToSuperview()
-            $0.top.equalToSuperview().inset(self.view.frame.height - self.keyboardHeight - self.bottomHeight)
-        }
-        
-        self.view.layoutIfNeeded()
-    }
-    
-    @objc
-    func hideBottomSheetAction() {
-        hideBottomSheet()
-    }
-    
-    @objc
-    func keyboardWillShow(_ notification: Notification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            keyboardHeight = keyboardSize.height
-            updateBottomSheetLayout()
-        }
-    }
-    
-    @objc
-    func keyboardWillHide(_ notification: Notification) {
-        keyboardHeight = 100
-        updateBottomSheetLayout()
     }
 }

--- a/TOASTER-iOS/Global/Components/ToasterBottomSheet/ToasterBottomSheetViewController.swift
+++ b/TOASTER-iOS/Global/Components/ToasterBottomSheet/ToasterBottomSheetViewController.swift
@@ -44,9 +44,7 @@ final class ToasterBottomSheetViewController: UIViewController {
 extension ToasterBottomSheetViewController {
     func setupSheetPresentation(bottomHeight: CGFloat) {
         if let sheet = self.sheetPresentationController {
-            if #available(iOS 16.0, *) {
-                sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
-            }
+            sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
             sheet.preferredCornerRadius = 20
         }
     }
@@ -54,9 +52,7 @@ extension ToasterBottomSheetViewController {
     func setupSheetHeightChanges(bottomHeight: CGFloat) {
         if let sheet = self.sheetPresentationController {
             sheet.animateChanges {
-                if #available(iOS 16.0, *) {
-                    sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
-                }
+                sheet.detents = [.custom(resolver: { _ in bottomHeight - 40 })]
             }
         }
     }

--- a/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
@@ -24,9 +24,8 @@ final class SelectClipViewController: UIViewController {
     private let clipSelectCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     private let completeButton: UIButton = UIButton()
     private let addClipBottomSheetView = AddClipBottomSheetView()
-    private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white, 
+    private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white,
                                                                       bottomTitle: "클립 추가",
-                                                                      height: 198,
                                                                       insertView: addClipBottomSheetView)
     
     private var selectedClipTapped: RemindClipModel? {
@@ -63,10 +62,10 @@ private extension SelectClipViewController {
         view.backgroundColor = .toasterBackground
         
         clipSelectCollectionView.do {
-            $0.register(RemindSelectClipCollectionViewCell.self, 
+            $0.register(RemindSelectClipCollectionViewCell.self,
                         forCellWithReuseIdentifier: RemindSelectClipCollectionViewCell.className)
             
-            $0.register(SelectClipHeaderView.self, 
+            $0.register(SelectClipHeaderView.self,
                         forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                         withReuseIdentifier: SelectClipHeaderView.className)
             
@@ -84,7 +83,7 @@ private extension SelectClipViewController {
     }
     
     func setupHierarchy() {
-        view.addSubviews(clipSelectCollectionView, 
+        view.addSubviews(clipSelectCollectionView,
                          completeButton)
     }
     
@@ -129,7 +128,7 @@ private extension SelectClipViewController {
     func moveBottomAction(isDuplicated: Bool) {
         if isDuplicated {
             addHeightBottom()
-            addClipBottomSheetView.changeTextField(addButton: false, 
+            addClipBottomSheetView.changeTextField(addButton: false,
                                                    border: true,
                                                    error: true,
                                                    clearButton: true)
@@ -140,11 +139,12 @@ private extension SelectClipViewController {
     }
     
     func addClipAction() {
-        addClipBottomSheetView.resetTextField()
-        addClipBottom.hideBottomSheet()
-        showToastMessage(width: 157, 
-                         status: .check,
-                         message: StringLiterals.ToastMessage.completeAddClip)
+        dismiss(animated: true) {
+            self.addClipBottomSheetView.resetTextField()
+            self.showToastMessage(width: 157,
+                                  status: .check,
+                                  message: StringLiterals.ToastMessage.completeAddClip)
+        }
     }
     
     func saveLinkAction() {
@@ -154,7 +154,7 @@ private extension SelectClipViewController {
     
     func saveFailAction() {
         self.navigationController?.popToRootViewController(animated: true)
-        self.navigationController?.showToastMessage(width: 200, 
+        self.navigationController?.showToastMessage(width: 200,
                                                     status: .warning,
                                                     message: "링크 저장에 실패했어요!")
     }
@@ -186,14 +186,14 @@ private extension SelectClipViewController {
     }
     
     @objc func completeButtonTapped() {
-        viewModel.postSaveLink(url: linkURL, 
+        viewModel.postSaveLink(url: linkURL,
                                category: categoryID)
     }
 }
 
 // MARK: - UICollectionViewDelegate
 
-extension SelectClipViewController: UICollectionViewDelegate { 
+extension SelectClipViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if indexPath.item != 0 {
             if let cell = collectionView.cellForItem(at: .SubSequence(item: 0, section: 0)) {
@@ -203,7 +203,7 @@ extension SelectClipViewController: UICollectionViewDelegate {
         categoryID = viewModel.selectedClip[indexPath.item].id
     }
     
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         willDisplay cell: UICollectionViewCell,
                         forItemAt indexPath: IndexPath) {
         if indexPath.item == 0 {
@@ -233,7 +233,7 @@ extension SelectClipViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         if kind == UICollectionView.elementKindSectionHeader {
-            guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, 
+            guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader,
                                                                                    withReuseIdentifier: SelectClipHeaderView.className,
                                                                                    for: indexPath) as? SelectClipHeaderView else { return UICollectionReusableView() }
             headerView.selectClipHeaderViewDelegate = self
@@ -245,7 +245,7 @@ extension SelectClipViewController: UICollectionViewDataSource {
     }
     
     // Header 크기 지정
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         referenceSizeForHeaderInSection section: Int) -> CGSize {
         return CGSize(width: 335, height: 68)
@@ -255,19 +255,19 @@ extension SelectClipViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegateFlowLayout
 
 extension SelectClipViewController: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, 
-                        layout collectionViewLayout: UICollectionViewLayout, 
+    func collectionView(_ collectionView: UICollectionView,
+                        layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: view.convertByWidthRatio(335), height: 52)
     }
     
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     }
     
-    func collectionView(_ collectionView: UICollectionView, 
+    func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 8
@@ -277,12 +277,12 @@ extension SelectClipViewController: UICollectionViewDelegateFlowLayout {
 extension SelectClipViewController: SelectClipHeaderViewlDelegate {
     func addClipCellTapped() {
         if viewModel.selectedClip.count > 15 {
-            showToastMessage(width: 243, 
-                             status: .warning, 
+            showToastMessage(width: 243,
+                             status: .warning,
                              message: StringLiterals.ToastMessage.noticeMaxClip)
         } else {
-            addClipBottom.modalPresentationStyle = .overFullScreen
-            self.present(addClipBottom, animated: false)
+            addClipBottom.setupSheetPresentation(bottomHeight: 198)
+            self.present(addClipBottom, animated: true)
         }
     }
 }
@@ -297,17 +297,16 @@ extension SelectClipViewController: AddClipBottomSheetViewDelegate {
     }
     
     func addHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 219)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 219)
     }
     
     func minusHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 198)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 198)
     }
     
     func dismissButtonTapped() {
-        addClipBottom.hideBottomSheet()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            self.showToastMessage(width: 157, 
+        dismiss(animated: true) {
+            self.showToastMessage(width: 157,
                                   status: .check,
                                   message: StringLiterals.ToastMessage.completeAddClip)
             self.addClipBottomSheetView.resetTextField()

--- a/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
+++ b/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
@@ -17,8 +17,11 @@ final class ClipViewController: UIViewController {
     private let viewModel = ClipViewModel()
     private let clipEmptyView = ClipEmptyView()
     private let addClipBottomSheetView = AddClipBottomSheetView()
-    private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white, bottomTitle: "클립 추가", height: 198, insertView: addClipBottomSheetView)
-    private let clipListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white, 
+                                                                      bottomTitle: "클립 추가",
+                                                                      insertView: addClipBottomSheetView)
+    private let clipListCollectionView = UICollectionView(frame: .zero, 
+                                                          collectionViewLayout: UICollectionViewFlowLayout())
     
     // MARK: - Life Cycle
     
@@ -91,8 +94,9 @@ private extension ClipViewController {
     }
     
     func addClipAction() {
-        addClipBottomSheetView.resetTextField()
-        addClipBottom.hideBottomSheet()
+        dismiss(animated: true) {
+            self.addClipBottomSheetView.resetTextField()
+        }
         showToastMessage(width: 157, status: .check, message: StringLiterals.ToastMessage.completeAddClip)
     }
     
@@ -208,19 +212,19 @@ extension ClipViewController: ClipCollectionHeaderViewDelegate {
         if viewModel.clipList.clips.count >= 15 {
             showToastMessage(width: 243, status: .warning, message: StringLiterals.ToastMessage.noticeMaxClip)
         } else {
-            addClipBottom.modalPresentationStyle = .overFullScreen
-            self.present(addClipBottom, animated: false)
+            addClipBottom.setupSheetPresentation(bottomHeight: 198)
+            present(addClipBottom, animated: true)
         }
     }
 }
 
 extension ClipViewController: AddClipBottomSheetViewDelegate {
     func addHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 219)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 219)
     }
     
     func minusHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 198)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 198)
     }
     
     func dismissButtonTapped(title: String) {

--- a/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
+++ b/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
@@ -70,8 +70,8 @@ final class AddClipBottomSheetView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
         setupKeyboard()
     }
 }
@@ -81,7 +81,6 @@ final class AddClipBottomSheetView: UIView {
 extension AddClipBottomSheetView {
     func resetTextField() {
         addClipTextField.text = nil
-        addClipTextField.becomeFirstResponder()
     }
     
     func changeTextField(addButton: Bool, border: Bool, error: Bool, clearButton: Bool) {

--- a/TOASTER-iOS/Present/DetailClip/View/Component/EditLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/EditLinkBottomSheetView.swift
@@ -1,5 +1,5 @@
 //
-//  DetailEditLinkBottomSheetView.swift
+//  EditLinkBottomSheetView.swift
 //  TOASTER-iOS
 //
 //  Created by Gahyun Kim on 2024/04/12.
@@ -70,8 +70,8 @@ final class EditLinkBottomSheetView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
         setupKeyboard()
     }
 }

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -23,13 +23,11 @@ final class DetailClipViewController: UIViewController {
     private let deleteLinkBottomSheetView = DeleteLinkBottomSheetView()
     private lazy var editBottom = ToasterBottomSheetViewController(bottomType: .gray,
                                                                bottomTitle: "수정하기",
-                                                               height: 126,
                                                                insertView: deleteLinkBottomSheetView)
     
     private let editLinkBottomSheetView = EditLinkBottomSheetView()
     private lazy var editLinkBottom = ToasterBottomSheetViewController(bottomType: .white,
                                                                        bottomTitle: "링크 제목 편집",
-                                                                       height: 198,
                                                                        insertView: editLinkBottomSheetView)
     
     // MARK: - Life Cycle
@@ -161,18 +159,16 @@ extension DetailClipViewController: UICollectionViewDataSource {
         }
         deleteLinkBottomSheetView.setupDeleteLinkBottomSheetButtonAction {
             self.viewModel.deleteLinkAPI(toastId: self.viewModel.toastId)
-            self.editBottom.hideBottomSheet()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                self.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeDeleteLink)
+            self.dismiss(animated: true) { [weak self] in
+                self?.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeDeleteLink)
             }
         }
         deleteLinkBottomSheetView.setupEditLinkTitleBottomSheetButtonAction {
             self.viewModel.getDetailCategoryAPI(categoryID: self.viewModel.categoryId,
                                                 filter: DetailCategoryFilter.all)
-            self.editBottom.hideBottomSheet()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.dismiss(animated: true) {
                 self.viewModel.segmentIndex = indexPath.item - 1
-                self.editLinkBottom.modalPresentationStyle = .overFullScreen
+                self.editLinkBottom.setupSheetPresentation(bottomHeight: 198)
                 self.present(self.editLinkBottom, animated: true)
             }
         }
@@ -274,8 +270,8 @@ extension DetailClipViewController: DetailClipSegmentedDelegate {
 extension DetailClipViewController: DetailClipListCollectionViewCellDelegate {
     func modifiedButtonTapped(toastId: Int) {
         viewModel.toastId = toastId
-        editBottom.modalPresentationStyle = .overFullScreen
-        present(editBottom, animated: false)
+        editBottom.setupSheetPresentation(bottomHeight: 226)
+        present(editBottom, animated: true)
     }
 }
 
@@ -287,23 +283,18 @@ extension DetailClipViewController: EditLinkBottomSheetViewDelegate {
     }
     
     func addHeightBottom() {
-        editLinkBottom.changeHeightBottomSheet(height: 219)
+        editLinkBottom.setupSheetHeightChanges(bottomHeight: 219)
     }
     
     func minusHeightBottom() {
-        editLinkBottom.changeHeightBottomSheet(height: 198)
+        editLinkBottom.setupSheetHeightChanges(bottomHeight: 198)
     }
     
     func dismissButtonTapped(title: String) {
         viewModel.patchEditLinkTitleAPI(toastId: viewModel.toastId,
                                         title: title)
-        // 이중 바텀시트 순차적으로 내리기
-        editLinkBottom.hideBottomSheet()
-        editBottom.hideBottomSheet()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            guard let self else { return }
-            self.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeEditTitle)
+        dismiss(animated: true) { [weak self] in
+            self?.showToastMessage(width: 152, status: .check, message: StringLiterals.ToastMessage.completeEditTitle)
         }
     }
 }

--- a/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
+++ b/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
@@ -21,7 +21,6 @@ final class EditClipViewController: UIViewController {
     private let editClipBottomSheetView = AddClipBottomSheetView()
     private lazy var editClipBottom = ToasterBottomSheetViewController(bottomType: .white,
                                                                        bottomTitle: "클립 이름 수정",
-                                                                       height: 198,
                                                                        insertView: editClipBottomSheetView)
     
     // MARK: - Life Cycle
@@ -170,8 +169,8 @@ extension EditClipViewController: UICollectionViewDataSource {
             }
             cell.changeTitleButtonTapped {
                 self.viewModel.cellIndex = indexPath.item - 1
-                self.editClipBottom.modalPresentationStyle = .overFullScreen
-                self.present(self.editClipBottom, animated: false)
+                self.editClipBottom.setupSheetPresentation(bottomHeight: 198)
+                self.present(self.editClipBottom, animated: true)
                 self.editClipBottomSheetView.setupTextField(message: self.viewModel.clipList.clips[indexPath.item - 1].title)
             }
         }
@@ -242,8 +241,12 @@ extension EditClipViewController: UICollectionViewDropDelegate {
                 collectionView.deleteItems(at: [sourceIndexPath])
                 collectionView.insertItems(at: [destinationIndexPath])
                 coordinator.drop(item.dragItem, toItemAt: destinationIndexPath)
-                self.viewModel.patchEditPriorityCategoryAPI(requestBody: ClipPriorityEditModel(id: self.viewModel.clipList.clips[destinationIndexPath.item - 1].id,
-                                                                                               priority: destinationIndexPath.item - 1))
+                self.viewModel.patchEditPriorityCategoryAPI(
+                    requestBody: ClipPriorityEditModel(
+                        id: self.viewModel.clipList.clips[destinationIndexPath.item - 1].id,
+                        priority: destinationIndexPath.item - 1
+                    )
+                )
             }
         }
     }
@@ -257,17 +260,18 @@ extension EditClipViewController: AddClipBottomSheetViewDelegate {
     }
     
     func addHeightBottom() {
-        editClipBottom.changeHeightBottomSheet(height: 219)
+        editClipBottom.setupSheetHeightChanges(bottomHeight: 219)
     }
     
     func minusHeightBottom() {
-        editClipBottom.changeHeightBottomSheet(height: 198)
+        editClipBottom.setupSheetHeightChanges(bottomHeight: 198)
     }
     
     func dismissButtonTapped(title: String) {
-        editClipBottom.hideBottomSheet()
+        dismiss(animated: true)
         viewModel.patchEditaNameCategoryAPI(
             requestBody: ClipNameEditModel(id: viewModel.clipList.clips[viewModel.cellIndex].id,
-                                            title: title))
+                                           title: title)
+        )
     }
 }

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -19,7 +19,6 @@ final class HomeViewController: UIViewController {
     private let addClipBottomSheetView = AddClipBottomSheetView()
     private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white,
                                                                       bottomTitle: "클립 추가",
-                                                                      height: 198, 
                                                                       insertView: addClipBottomSheetView)
     
     // MARK: - Life Cycle
@@ -277,11 +276,12 @@ private extension HomeViewController {
     }
     
     func addClipAction() {
-        addClipBottomSheetView.resetTextField()
-        addClipBottom.hideBottomSheet()
-        showToastMessage(width: 157,
-                         status: .check,
-                         message: StringLiterals.ToastMessage.completeAddClip)
+        dismiss(animated: true) {
+            self.addClipBottomSheetView.resetTextField()
+            self.showToastMessage(width: 157,
+                                  status: .check,
+                                  message: StringLiterals.ToastMessage.completeAddClip)
+        }
     }
     
     func setupNavigationBar() {
@@ -318,11 +318,11 @@ extension HomeViewController: AddClipBottomSheetViewDelegate {
     }
     
     func addHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 219)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 219)
     }
     
     func minusHeightBottom() {
-        addClipBottom.changeHeightBottomSheet(height: 198)
+        addClipBottom.setupSheetHeightChanges(bottomHeight: 198)
     }
     
     func dismissButtonTapped(title: String) {
@@ -334,8 +334,8 @@ extension HomeViewController: AddClipBottomSheetViewDelegate {
 
 extension HomeViewController: UserClipCollectionViewCellDelegate {
     func addClipCellTapped() {
-        addClipBottom.modalPresentationStyle = .overFullScreen
-        self.present(addClipBottom, animated: false)
+        addClipBottom.setupSheetPresentation(bottomHeight: 198)
+        self.present(addClipBottom, animated: true)
     }
 }
 

--- a/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
+++ b/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
@@ -182,11 +182,9 @@ private extension RemindViewController {
         
         let exampleBottom = ToasterBottomSheetViewController(bottomType: .gray, 
                                                              bottomTitle: "수정하기",
-                                                             height: 128,
                                                              insertView: editView)
-        exampleBottom.modalPresentationStyle = .overFullScreen
-        
-        present(exampleBottom, animated: false)
+        exampleBottom.setupSheetPresentation(bottomHeight: 226)
+        present(exampleBottom, animated: true)
     }
     
     func setupAlarmBottomSheet() {
@@ -195,11 +193,9 @@ private extension RemindViewController {
         
         let exampleBottom = ToasterBottomSheetViewController(bottomType: .white, 
                                                              bottomTitle: "알림이 꺼져있어요!",
-                                                             height: 311,
                                                              insertView: alarmView)
-        exampleBottom.modalPresentationStyle = .overFullScreen
-        
-        present(exampleBottom, animated: false)
+        exampleBottom.setupSheetPresentation(bottomHeight: 427)
+        present(exampleBottom, animated: true)
     }
     
     func reloadCollectionViewWithView(forType: RemindViewType) {
@@ -265,7 +261,7 @@ extension RemindViewController: RemindAlarmOffBottomSheetViewDelegate {
 extension RemindViewController: RemindEditViewDelegate {
     func editTimer(forID: Int?) {
         selectedTimerID = forID
-        dismiss(animated: false)
+        dismiss(animated: true)
         if let forID {
             let editViewController = RemindTimerAddViewController()
             editViewController.configureView(forTimerID: forID)
@@ -275,7 +271,7 @@ extension RemindViewController: RemindEditViewDelegate {
     
     func deleteTimer(forID: Int?) {
         selectedTimerID = forID
-        dismiss(animated: false)
+        dismiss(animated: true)
         showPopup(forMainText: "타이머를 삭제하시겠어요?",
                   forSubText: "더 이상 해당 클립의 리마인드를 \n받을 수 없어요",
                   forLeftButtonTitle: StringLiterals.Button.cancel,

--- a/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
@@ -358,9 +358,11 @@ private extension RemindTimerAddViewController {
         let repeatView = TimerRepeatBottomSheetView()
         repeatView.setupDelegate(forDelegate: self)
         repeatView.setupSelectedIndex(forIndexList: selectedIndex)
-        let exampleBottom = ToasterBottomSheetViewController(bottomType: .gray, bottomTitle: "반복설정", height: view.convertByHeightRatio(622), insertView: repeatView)
-        exampleBottom.modalPresentationStyle = .overFullScreen
-        self.present(exampleBottom, animated: false)
+        let exampleBottom = ToasterBottomSheetViewController(bottomType: .gray, 
+                                                             bottomTitle: "반복설정",
+                                                             insertView: repeatView)
+        exampleBottom.setupSheetPresentation(bottomHeight: view.convertByHeightRatio(720))
+        self.present(exampleBottom, animated: true)
     }
     
     @objc func completeButtonTapped() {
@@ -391,6 +393,6 @@ extension RemindTimerAddViewController: TimerRepeatBottomSheetDelegate {
         setSelectedIndex(contains: 9, deleteFirst: 1, deleteSecond: 5)
         setSelectedIndex(contains: 10, deleteFirst: 6, deleteSecond: 7)
         
-        dismiss(animated: false)
+        dismiss(animated: true)
     }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #193

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- 바텀시트 애니메이션 안정성을 위해 UISheetPresentationController로 전면 수정했습니다.
- UISheetPresentationController의 지원 버전이 iOS 16 이후인지라, 최소 앱 지원버전을 15 -> 16으로 변경했습니다.
- 자세한 내용은 [제 블로그](https://mini-min-dev.tistory.com/294)에 잘 써놨으니 확인하시면 됩니다~~

## 🖥️ 주요 코드 사용법
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
- Sheet 사용 시
```swift
let exampleView = UIView()  // 시트에 들어갈 뷰
let exampleBottom = ToasterBottomSheetViewController(bottomType: .gray, bottomTitle: "수정하기", insertView: exampleView)
exampleBottom.setupSheetPresentation(bottomHeight: 226)  // 높이 지정
present(exampleBottom, animated: true)  // animated = true 설정
```

- Sheet 내릴 때
```swift
dismiss(animated: true) {
    // Completion이 필요한 경우 추가
}
```

- Sheet 높이를 수정할 때
```swift
exampleBottom.setupSheetHeightChanges(bottomHeight: 310)  // 수정하고 싶은 높이 지정
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
