### PR TITLE
[Fix] #199 - 최초 15글자 초과 시 지우기 버튼 동작 안하는 버그 해결

### DIFF
--- a/TOASTER-iOS/Present/DetailClip/View/Component/EditLinkBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/EditLinkBottomSheetView.swift
@@ -244,7 +244,7 @@ extension EditLinkBottomSheetView: UITextFieldDelegate {
         if currentText.count == maxLength && newText.count == 15 {
             editLinkBottomSheetViewDelegate?.minusHeightBottom()
         }
-        return newText.count <= maxLength
+        return (newText.count <= maxLength) || (newText.count < currentText.count)
     }
     
     func textFieldDidChangeSelection(_ textField: UITextField) {


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #199 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
링크 제목 편집 시 발생하던 버그 수정했습니다.

- 기존 상황 : 애초에 링크가 15글자가 초과하는 경우, 지우기 버튼을 눌러도 키보드 입력이 막히던 상황
- 개선 상황 : 15글자가 초과하더라도 지우기 버튼을 통해 글자가 줄어드는 경우는 가능하도록 조건을 추가 / 글자수가 늘어나는 조건은 불가

|  기존 문제 화면 |  개선된 화면  |  기존 글자 수 초과 상황, 정상 동작 여부 확인 |  
| :-------------: | :----------: | :----------: | 
| <img src = "https://github.com/user-attachments/assets/cf8f797e-53f5-4d07-b526-8fd29d8a61f0" width ="250"> | <img src = "https://github.com/user-attachments/assets/70d8ce88-419b-4c12-835e-e1c98aa4bb24" width ="250"> | <img src = "https://github.com/user-attachments/assets/5f057177-545e-4b9c-aa9c-f16d1c840101" width ="250"> | 

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
