### PR TITLE
[Feat] #202 - 앱 최초 진입 시 설문조사 팝업 로직 구현

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,11 @@
 		3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */; };
 		391908422B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */; };
 		391908442B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */; };
+		396DCDE52CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */; };
+		396DCDE82CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */; };
+		396DCDEB2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
+		396DCDEE2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */; };
+		396DCDF12CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */; };
 		398ACFDC2B5E77FA00D5EE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */; };
 		398BE7F32B456367001595E0 /* ToasterToastMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */; };
 		398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F52B456AF9001595E0 /* BottomType.swift */; };
@@ -323,6 +328,11 @@
 		3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAlertType.swift; sourceTree = "<group>"; };
 		391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditPriorityCategoryRequestDTO.swift; sourceTree = "<group>"; };
 		391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditNameCategoryRequestDTO.swift; sourceTree = "<group>"; };
+		396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTargetType.swift; sourceTree = "<group>"; };
+		396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAPIService.swift; sourceTree = "<group>"; };
+		396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPopupInfoResponseDTO.swift; sourceTree = "<group>"; };
+		396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenRequestDTO.swift; sourceTree = "<group>"; };
+		396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenResponseDTO.swift; sourceTree = "<group>"; };
 		398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterToastMessageView.swift; sourceTree = "<group>"; };
 		398BE7F52B456AF9001595E0 /* BottomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomType.swift; sourceTree = "<group>"; };
@@ -599,6 +609,26 @@
 				3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */,
 			);
 			path = UpdateAlert;
+			sourceTree = "<group>";
+		};
+		396DCDE22CA199E800FEF7C8 /* Popup */ = {
+			isa = PBXGroup;
+			children = (
+				396DCDE32CA19A0400FEF7C8 /* DTO */,
+				396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */,
+				396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */,
+			);
+			path = Popup;
+			sourceTree = "<group>";
+		};
+		396DCDE32CA19A0400FEF7C8 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */,
+				396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */,
+				396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */,
+			);
+			path = DTO;
 			sourceTree = "<group>";
 		};
 		398ACFDA2B5E77C500D5EE77 /* Assets */ = {
@@ -965,6 +995,7 @@
 				6BE6DA792B5456FE008B06FA /* Toaster */,
 				6BE6DA8D2B546EE2008B06FA /* Timer */,
 				6BE6DAA92B547978008B06FA /* Search */,
+				396DCDE22CA199E800FEF7C8 /* Popup */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1774,6 +1805,7 @@
 				3F1F261D2BAA98C8004F75CE /* RemindClipModel.swift in Sources */,
 				3F3ED28C2BA1A456004E79F0 /* PostRefreshTokenResponseDTO.swift in Sources */,
 				3F3ED28D2BA1A456004E79F0 /* AuthAPIService.swift in Sources */,
+				396DCDEB2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				3F3ED2892BA1A453004E79F0 /* PostSocialLoginRequestDTO.swift in Sources */,
 				3F3ED27B2BA1A298004E79F0 /* BaseTargetType.swift in Sources */,
 				3F3ED28E2BA1A45C004E79F0 /* PatchPushAlarmRequestDTO.swift in Sources */,
@@ -1784,6 +1816,7 @@
 				3F7D917A2BA1A05F004A022F /* UIView+.swift in Sources */,
 				3F3ED2AE2BA1CD10004E79F0 /* BottomType.swift in Sources */,
 				3F3ED2822BA1A3F8004E79F0 /* ClipTargetType.swift in Sources */,
+				396DCDEE2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				3FE00F0C2BC632A500CC821E /* NetworkResult.swift in Sources */,
 				83474A6D2BED0750009B9C48 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
 				3F3ED2832BA1A3FD004E79F0 /* GetAllCategoryResponseDTO.swift in Sources */,
@@ -1792,8 +1825,10 @@
 				3F3ED2902BA1A45F004E79F0 /* PatchPushAlarmResponseDTO.swift in Sources */,
 				3F3ED2912BA1A45F004E79F0 /* UserTargetType.swift in Sources */,
 				3F3ED2922BA1A45F004E79F0 /* GetSettingPageResponseDTO.swift in Sources */,
+				396DCDE82CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */,
 				3F3ED2932BA1A45F004E79F0 /* GetMyPageResponseDTO.swift in Sources */,
 				3F3ED2B62BA1D6C8004E79F0 /* UILabel+.swift in Sources */,
+				396DCDF22CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
 				3FE00F0B2BC6328900CC821E /* MoyaPlugin.swift in Sources */,
 				3F1F261B2BAA9820004F75CE /* RemindSelectClipCollectionViewCell.swift in Sources */,
 				83474A6C2BED072A009B9C48 /* ToasterAPIService.swift in Sources */,
@@ -1810,6 +1845,7 @@
 				3F3ED2972BA1A46E004E79F0 /* GetWeeksLinkResponseDTO.swift in Sources */,
 				3F3ED29B2BA1A475004E79F0 /* PatchEditTimerRequestDTO.swift in Sources */,
 				3F3ED29C2BA1A475004E79F0 /* PatchEditTimerTitleRequestDTO.swift in Sources */,
+				396DCDE52CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */,
 				3F3ED29D2BA1A475004E79F0 /* PostCreateTimerRequestDTO.swift in Sources */,
 				3F1F26262BAAC231004F75CE /* ShareViewController.swift in Sources */,
 				3F1F26222BAAB395004F75CE /* ToasterToastMessageView.swift in Sources */,
@@ -1847,8 +1883,10 @@
 				6BE6D9E22B4E9B58008B06FA /* CompleteTimerCollectionViewCell.swift in Sources */,
 				3F2FA1792B45C46F00EDBF95 /* KakaoAuthenticateAdapter.swift in Sources */,
 				6BE6DA342B50594B008B06FA /* MoyaPlugin.swift in Sources */,
+				396DCDE62CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */,
 				6BE6D9D82B4E8A03008B06FA /* RemindAlarmOffViewType.swift in Sources */,
 				398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */,
+				396DCDE92CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */,
 				8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
 				3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */,
 				6BE6DA5B2B50B46F008B06FA /* GetMainPageResponseDTO.swift in Sources */,
@@ -1914,6 +1952,7 @@
 				6BE6D9E42B4EA125008B06FA /* WaitTimerCollectionViewCell.swift in Sources */,
 				6BE6D9D42B4DE479008B06FA /* RemindTimerEmptyView.swift in Sources */,
 				39B54E7A2B53D49900538DAE /* SettingTableViewCell.swift in Sources */,
+				396DCDF12CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
 				39A843C52B736039007A4D75 /* ClipViewModel.swift in Sources */,
 				6BE6DA392B50636B008B06FA /* BaseAPIService.swift in Sources */,
 				6BE6DA572B50B44F008B06FA /* GetMyPageResponseDTO.swift in Sources */,
@@ -1926,6 +1965,7 @@
 				3909A06D2B62375E005A4546 /* LinkReadEditModel.swift in Sources */,
 				6BC4935E2B4414B400544249 /* ToasterPopupViewController.swift in Sources */,
 				39BE4BBE2B4ABB7C002B471D /* DetailClipSegmentedControlView.swift in Sources */,
+				396DCDEC2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				6BE6DA6D2B50C109008B06FA /* GetDetailCategoryResponseDTO.swift in Sources */,
 				6B6AE6A82B3FF6D5000E2366 /* UITextField+.swift in Sources */,
 				6BE6DA652B50BA4F008B06FA /* PostAddCategoryRequestDTO.swift in Sources */,
@@ -1954,6 +1994,7 @@
 				6BE6DA9A2B54747B008B06FA /* TimerAPIService.swift in Sources */,
 				6BE6DA882B546B24008B06FA /* PatchOpenLinkResponseDTO.swift in Sources */,
 				6BE6DA752B50C373008B06FA /* GetCheckCategoryResponseDTO.swift in Sources */,
+				396DCDEF2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				6BE6D9EF2B4EE98D008B06FA /* RemindModel.swift in Sources */,
 				6BE6DA6B2B50BFED008B06FA /* NoneDataResponseDTO.swift in Sources */,
 				391908422B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		396DCDFE2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */; };
 		396DCE002CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
 		396DCE012CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
+		396DCE032CA26C6600FEF7C8 /* PopupInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCE022CA26C6600FEF7C8 /* PopupInfoModel.swift */; };
 		398ACFDC2B5E77FA00D5EE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */; };
 		398BE7F32B456367001595E0 /* ToasterToastMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */; };
 		398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F52B456AF9001595E0 /* BottomType.swift */; };
@@ -338,6 +339,7 @@
 		396DCDF92CA19F2000FEF7C8 /* PopupTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTargetType.swift; sourceTree = "<group>"; };
 		396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenRequestDTO.swift; sourceTree = "<group>"; };
 		396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPopupInfoResponseDTO.swift; sourceTree = "<group>"; };
+		396DCE022CA26C6600FEF7C8 /* PopupInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupInfoModel.swift; sourceTree = "<group>"; };
 		398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterToastMessageView.swift; sourceTree = "<group>"; };
 		398BE7F52B456AF9001595E0 /* BottomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomType.swift; sourceTree = "<group>"; };
@@ -1567,6 +1569,7 @@
 				8305179C2B4D3701009FFB60 /* MainInfoModel.swift */,
 				83CFC3362B564F1100A2EB2B /* WeeklyLinkModel.swift */,
 				83CFC3382B568BE700A2EB2B /* RecommendSiteModel.swift */,
+				396DCE022CA26C6600FEF7C8 /* PopupInfoModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1929,6 +1932,7 @@
 				830517652B42D996009FFB60 /* StringLiterals.swift in Sources */,
 				8305178C2B4D1E64009FFB60 /* WeeklyLinkCollectionViewCell.swift in Sources */,
 				8315CD842B501BC70061F377 /* UserClipEmptyCollectionViewCell.swift in Sources */,
+				396DCE032CA26C6600FEF7C8 /* PopupInfoModel.swift in Sources */,
 				6BC493812B4D88E200544249 /* SearchViewModel.swift in Sources */,
 				6BE6DA942B546FCB008B06FA /* PostCreateTimerRequestDTO.swift in Sources */,
 				6BE6DA042B4F2AF5008B06FA /* RemindSelectClipCollectionViewCell.swift in Sources */,

--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -23,11 +23,16 @@
 		3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */; };
 		391908422B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */; };
 		391908442B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */; };
-		396DCDE52CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */; };
-		396DCDE82CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */; };
-		396DCDEB2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
-		396DCDEE2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */; };
-		396DCDF12CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */; };
+		396DCDF42CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF32CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift */; };
+		396DCDF52CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF32CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift */; };
+		396DCDF72CA19EFD00FEF7C8 /* PopupAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF62CA19EFD00FEF7C8 /* PopupAPIService.swift */; };
+		396DCDF82CA19EFD00FEF7C8 /* PopupAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF62CA19EFD00FEF7C8 /* PopupAPIService.swift */; };
+		396DCDFA2CA19F2000FEF7C8 /* PopupTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF92CA19F2000FEF7C8 /* PopupTargetType.swift */; };
+		396DCDFB2CA19F2000FEF7C8 /* PopupTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDF92CA19F2000FEF7C8 /* PopupTargetType.swift */; };
+		396DCDFD2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */; };
+		396DCDFE2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */; };
+		396DCE002CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
+		396DCE012CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */; };
 		398ACFDC2B5E77FA00D5EE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */; };
 		398BE7F32B456367001595E0 /* ToasterToastMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */; };
 		398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F52B456AF9001595E0 /* BottomType.swift */; };
@@ -328,11 +333,11 @@
 		3913B0AF2BCECFC80031A3EB /* UpdateAlertType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAlertType.swift; sourceTree = "<group>"; };
 		391908412B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditPriorityCategoryRequestDTO.swift; sourceTree = "<group>"; };
 		391908432B56D027006F978A /* PatchEditNameCategoryRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchEditNameCategoryRequestDTO.swift; sourceTree = "<group>"; };
-		396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTargetType.swift; sourceTree = "<group>"; };
-		396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAPIService.swift; sourceTree = "<group>"; };
-		396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPopupInfoResponseDTO.swift; sourceTree = "<group>"; };
-		396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenRequestDTO.swift; sourceTree = "<group>"; };
-		396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenResponseDTO.swift; sourceTree = "<group>"; };
+		396DCDF32CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenResponseDTO.swift; sourceTree = "<group>"; };
+		396DCDF62CA19EFD00FEF7C8 /* PopupAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAPIService.swift; sourceTree = "<group>"; };
+		396DCDF92CA19F2000FEF7C8 /* PopupTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupTargetType.swift; sourceTree = "<group>"; };
+		396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchPopupHiddenRequestDTO.swift; sourceTree = "<group>"; };
+		396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPopupInfoResponseDTO.swift; sourceTree = "<group>"; };
 		398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterToastMessageView.swift; sourceTree = "<group>"; };
 		398BE7F52B456AF9001595E0 /* BottomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomType.swift; sourceTree = "<group>"; };
@@ -615,8 +620,8 @@
 			isa = PBXGroup;
 			children = (
 				396DCDE32CA19A0400FEF7C8 /* DTO */,
-				396DCDE42CA19A1300FEF7C8 /* PopupTargetType.swift */,
-				396DCDE72CA19A2300FEF7C8 /* PopupAPIService.swift */,
+				396DCDF92CA19F2000FEF7C8 /* PopupTargetType.swift */,
+				396DCDF62CA19EFD00FEF7C8 /* PopupAPIService.swift */,
 			);
 			path = Popup;
 			sourceTree = "<group>";
@@ -624,9 +629,9 @@
 		396DCDE32CA19A0400FEF7C8 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
-				396DCDEA2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift */,
-				396DCDED2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift */,
-				396DCDF02CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift */,
+				396DCDFF2CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift */,
+				396DCDFC2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift */,
+				396DCDF32CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1801,11 +1806,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F3ED28A2BA1A456004E79F0 /* AuthTargetType.swift in Sources */,
+				396DCDFD2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				3F3ED28B2BA1A456004E79F0 /* PostSocialLoginResponseDTO.swift in Sources */,
 				3F1F261D2BAA98C8004F75CE /* RemindClipModel.swift in Sources */,
 				3F3ED28C2BA1A456004E79F0 /* PostRefreshTokenResponseDTO.swift in Sources */,
 				3F3ED28D2BA1A456004E79F0 /* AuthAPIService.swift in Sources */,
-				396DCDEB2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				3F3ED2892BA1A453004E79F0 /* PostSocialLoginRequestDTO.swift in Sources */,
 				3F3ED27B2BA1A298004E79F0 /* BaseTargetType.swift in Sources */,
 				3F3ED28E2BA1A45C004E79F0 /* PatchPushAlarmRequestDTO.swift in Sources */,
@@ -1816,7 +1821,6 @@
 				3F7D917A2BA1A05F004A022F /* UIView+.swift in Sources */,
 				3F3ED2AE2BA1CD10004E79F0 /* BottomType.swift in Sources */,
 				3F3ED2822BA1A3F8004E79F0 /* ClipTargetType.swift in Sources */,
-				396DCDEE2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				3FE00F0C2BC632A500CC821E /* NetworkResult.swift in Sources */,
 				83474A6D2BED0750009B9C48 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
 				3F3ED2832BA1A3FD004E79F0 /* GetAllCategoryResponseDTO.swift in Sources */,
@@ -1825,14 +1829,14 @@
 				3F3ED2902BA1A45F004E79F0 /* PatchPushAlarmResponseDTO.swift in Sources */,
 				3F3ED2912BA1A45F004E79F0 /* UserTargetType.swift in Sources */,
 				3F3ED2922BA1A45F004E79F0 /* GetSettingPageResponseDTO.swift in Sources */,
-				396DCDE82CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */,
 				3F3ED2932BA1A45F004E79F0 /* GetMyPageResponseDTO.swift in Sources */,
 				3F3ED2B62BA1D6C8004E79F0 /* UILabel+.swift in Sources */,
-				396DCDF22CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
+				396DCDF42CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
 				3FE00F0B2BC6328900CC821E /* MoyaPlugin.swift in Sources */,
 				3F1F261B2BAA9820004F75CE /* RemindSelectClipCollectionViewCell.swift in Sources */,
 				83474A6C2BED072A009B9C48 /* ToasterAPIService.swift in Sources */,
 				3F3ED29E2BA1A478004E79F0 /* TimerAPIService.swift in Sources */,
+				396DCE002CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				3F3ED29F2BA1A478004E79F0 /* GetTimerMainpageResponseDTO.swift in Sources */,
 				3F3ED2A02BA1A478004E79F0 /* TimerTargetType.swift in Sources */,
 				3F3ED2AA2BA1AAB7004E79F0 /* FontLiterals.swift in Sources */,
@@ -1845,7 +1849,6 @@
 				3F3ED2972BA1A46E004E79F0 /* GetWeeksLinkResponseDTO.swift in Sources */,
 				3F3ED29B2BA1A475004E79F0 /* PatchEditTimerRequestDTO.swift in Sources */,
 				3F3ED29C2BA1A475004E79F0 /* PatchEditTimerTitleRequestDTO.swift in Sources */,
-				396DCDE52CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */,
 				3F3ED29D2BA1A475004E79F0 /* PostCreateTimerRequestDTO.swift in Sources */,
 				3F1F26262BAAC231004F75CE /* ShareViewController.swift in Sources */,
 				3F1F26222BAAB395004F75CE /* ToasterToastMessageView.swift in Sources */,
@@ -1857,11 +1860,13 @@
 				3F3ED2A92BA1AAB4004E79F0 /* StringLiterals.swift in Sources */,
 				3F3ED2A22BA1A47E004E79F0 /* GetMainPageSearchResponseDTO.swift in Sources */,
 				3F3ED2A32BA1A47E004E79F0 /* SearchTargetType.swift in Sources */,
+				396DCDFB2CA19F2000FEF7C8 /* PopupTargetType.swift in Sources */,
 				3F3ED2A42BA1A47E004E79F0 /* GetRecommendSiteResponseDTO.swift in Sources */,
 				3F3ED2A52BA1A47E004E79F0 /* SearchAPIService.swift in Sources */,
 				3F3ED2962BA1A46B004E79F0 /* PostSaveLinkRequestDTO.swift in Sources */,
 				3F3ED2882BA1A400004E79F0 /* PatchEditPriorityCategoryRequestDTO.swift in Sources */,
 				3FE00F082BC5076200CC821E /* PostTokenHealthResponseDTO.swift in Sources */,
+				396DCDF72CA19EFD00FEF7C8 /* PopupAPIService.swift in Sources */,
 				3F3ED2842BA1A3FD004E79F0 /* GetCheckCategoryResponseDTO.swift in Sources */,
 				3F3ED2852BA1A3FD004E79F0 /* GetDetailCategoryResponseDTO.swift in Sources */,
 				3F3ED2802BA1A2B0004E79F0 /* APIInterceptor.swift in Sources */,
@@ -1883,11 +1888,11 @@
 				6BE6D9E22B4E9B58008B06FA /* CompleteTimerCollectionViewCell.swift in Sources */,
 				3F2FA1792B45C46F00EDBF95 /* KakaoAuthenticateAdapter.swift in Sources */,
 				6BE6DA342B50594B008B06FA /* MoyaPlugin.swift in Sources */,
-				396DCDE62CA19A1300FEF7C8 /* PopupTargetType.swift in Sources */,
+				396DCDFA2CA19F2000FEF7C8 /* PopupTargetType.swift in Sources */,
 				6BE6D9D82B4E8A03008B06FA /* RemindAlarmOffViewType.swift in Sources */,
 				398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */,
-				396DCDE92CA19A2300FEF7C8 /* PopupAPIService.swift in Sources */,
 				8364220C2BE7BFB2005C4085 /* PatchEditLinkTitleResponseDTO.swift in Sources */,
+				396DCDF82CA19EFD00FEF7C8 /* PopupAPIService.swift in Sources */,
 				3913B0B02BCECFC80031A3EB /* UpdateAlertType.swift in Sources */,
 				6BE6DA5B2B50B46F008B06FA /* GetMainPageResponseDTO.swift in Sources */,
 				3F2FA1772B45C3E000EDBF95 /* AuthenticationAdapterProtocol.swift in Sources */,
@@ -1952,7 +1957,6 @@
 				6BE6D9E42B4EA125008B06FA /* WaitTimerCollectionViewCell.swift in Sources */,
 				6BE6D9D42B4DE479008B06FA /* RemindTimerEmptyView.swift in Sources */,
 				39B54E7A2B53D49900538DAE /* SettingTableViewCell.swift in Sources */,
-				396DCDF12CA19A8900FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
 				39A843C52B736039007A4D75 /* ClipViewModel.swift in Sources */,
 				6BE6DA392B50636B008B06FA /* BaseAPIService.swift in Sources */,
 				6BE6DA572B50B44F008B06FA /* GetMyPageResponseDTO.swift in Sources */,
@@ -1965,7 +1969,6 @@
 				3909A06D2B62375E005A4546 /* LinkReadEditModel.swift in Sources */,
 				6BC4935E2B4414B400544249 /* ToasterPopupViewController.swift in Sources */,
 				39BE4BBE2B4ABB7C002B471D /* DetailClipSegmentedControlView.swift in Sources */,
-				396DCDEC2CA19A4C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				6BE6DA6D2B50C109008B06FA /* GetDetailCategoryResponseDTO.swift in Sources */,
 				6B6AE6A82B3FF6D5000E2366 /* UITextField+.swift in Sources */,
 				6BE6DA652B50BA4F008B06FA /* PostAddCategoryRequestDTO.swift in Sources */,
@@ -1994,8 +1997,9 @@
 				6BE6DA9A2B54747B008B06FA /* TimerAPIService.swift in Sources */,
 				6BE6DA882B546B24008B06FA /* PatchOpenLinkResponseDTO.swift in Sources */,
 				6BE6DA752B50C373008B06FA /* GetCheckCategoryResponseDTO.swift in Sources */,
-				396DCDEF2CA19A5C00FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
+				396DCE012CA19F5C00FEF7C8 /* GetPopupInfoResponseDTO.swift in Sources */,
 				6BE6D9EF2B4EE98D008B06FA /* RemindModel.swift in Sources */,
+				396DCDFE2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				6BE6DA6B2B50BFED008B06FA /* NoneDataResponseDTO.swift in Sources */,
 				391908422B56CFE4006F978A /* PatchEditPriorityCategoryRequestDTO.swift in Sources */,
 				6BE6DA732B50C33A008B06FA /* GetAllCategoryResponseDTO.swift in Sources */,
@@ -2025,6 +2029,7 @@
 				6BE6DAAD2B547A77008B06FA /* SearchTargetType.swift in Sources */,
 				6B6AE6512B3FF101000E2366 /* SceneDelegate.swift in Sources */,
 				3FACF9B82B4FE306007E5A8F /* KeyChainService.swift in Sources */,
+				396DCDF52CA19EC600FEF7C8 /* PatchPopupHiddenResponseDTO.swift in Sources */,
 				3F2FA1812B4A32A200EDBF95 /* LogoutUseCase.swift in Sources */,
 				6BE6D9D62B4E8935008B06FA /* RemindAlarmOffView.swift in Sources */,
 				3FA56CD72B85C76B00B9FCFE /* OnboardingViewController.swift in Sources */,

--- a/TOASTER-iOS/Application/SceneDelegate.swift
+++ b/TOASTER-iOS/Application/SceneDelegate.swift
@@ -65,10 +65,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         if let pasteboardString = UIPasteboard.general.url {
             if appDelegate.isLogin {
-                if let rootViewController = window?.rootViewController as? ToasterNavigationController {
-                    let addLinkViewController = AddLinkViewController()
-                    rootViewController.pushViewController(addLinkViewController, animated: true)
-                    addLinkViewController.embedURL(url: UIPasteboard.general.string ?? "")
+                guard let rootVC = window?.rootViewController as? ToasterNavigationController else { return }
+                let addLinkViewController = AddLinkViewController()
+                rootVC.pushViewController(addLinkViewController, animated: true)
+                addLinkViewController.embedURL(url: UIPasteboard.general.string ?? "")
+                                
+                if let presentedVC = rootVC.presentedViewController {
+                    presentedVC.dismiss(animated: false)
                 }
             }
         }

--- a/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
+++ b/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
@@ -115,9 +115,9 @@ final class ToasterPopupViewController: UIViewController {
         self.imageURL = imageURL
         self.centerButtonTitle = centerButtonTitle
         self.bottomButtonTitle = bottomButtonTitle
-        self.centerButtonHandler = nil
-        self.bottomButtonHandler = nil
-        self.closeButtonHandler = nil
+        self.centerButtonHandler = centerButtonHandler
+        self.bottomButtonHandler = bottomButtonHandler
+        self.closeButtonHandler = closeButtonHandler
 
         if bottomButtonTitle.isEmpty {
             self.popupType = .Confirmation
@@ -181,6 +181,7 @@ private extension ToasterPopupViewController {
         
         popupImage.do {
             $0.kf.setImage(with: URL(string: imageURL ?? ""))
+            $0.contentMode = .scaleAspectFit
         }
         
         buttonStackView.do {

--- a/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
+++ b/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
@@ -279,50 +279,21 @@ private extension ToasterPopupViewController {
     }
     
     func setupButtonAction() {
-        leftButton.addTarget(self, action: #selector(leftButtonTapped), for: .touchUpInside)
-        rightButton.addTarget(self, action: #selector(rightButtonTapped), for: .touchUpInside)
-        centerButton.addTarget(self, action: #selector(centerButtonTapped), for: .touchUpInside)
-        bottomButton.addTarget(self, action: #selector(bottomButtonTapped), for: .touchUpInside)
-        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        leftButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        rightButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        centerButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        bottomButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
     }
     
-    @objc func leftButtonTapped() {
-        if let leftButtonHandler {
-            leftButtonHandler()
-        } else {
-            cancelAction()
-        }
-    }
-    
-    @objc func rightButtonTapped() {
-        if let rightButtonHandler {
-            rightButtonHandler()
-        } else {
-            cancelAction()
-        }
-    }
-    
-    @objc func centerButtonTapped() {
-        if let centerButtonHandler {
-            centerButtonHandler()
-        } else {
-            cancelAction()
-        }
-    }
-    
-    @objc func bottomButtonTapped() {
-        if let bottomButtonHandler {
-            bottomButtonHandler()
-        } else {
-            cancelAction()
-        }
-    }
-    
-    @objc func closeButtonTapped() {
-        if let closeButtonHandler {
-            closeButtonHandler()
-        } else {
-            cancelAction()
+    @objc func buttonTapped(_ sender: UIButton) {
+        switch sender {
+        case leftButton: leftButtonHandler?() ?? cancelAction()
+        case rightButton: rightButtonHandler?() ?? cancelAction()
+        case centerButton: centerButtonHandler?() ?? cancelAction()
+        case bottomButton: bottomButtonHandler?() ?? cancelAction()
+        case closeButton: closeButtonHandler?() ?? cancelAction()
+        default: break
         }
     }
     

--- a/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
+++ b/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift
@@ -13,6 +13,7 @@ import Then
 enum ToasterPopupType {
     case Confirmation // 가운테 버튼 존재
     case Cancelable // 좌,우 버튼 존재
+    case Limitation // 가운데 버튼 아래 기간 설정 버튼 존재
 }
 
 final class ToasterPopupViewController: UIViewController {
@@ -24,12 +25,16 @@ final class ToasterPopupViewController: UIViewController {
     private var popupType: ToasterPopupType
     private var mainText: String?
     private var subText: String?
+    private var imageURL: String?
     private var leftButtonTitle: String = ""
     private var rightButtonTitle: String = ""
     private var centerButtonTitle: String = ""
+    private var bottomButtonTitle: String = ""
     private var leftButtonHandler: ButtonAction?
     private var rightButtonHandler: ButtonAction?
     private var centerButtonHandler: ButtonAction?
+    private var bottomButtonHandler: ButtonAction?
+    private var closeButtonHandler: ButtonAction?
     
     // MARK: - UI Properties
     
@@ -38,11 +43,14 @@ final class ToasterPopupViewController: UIViewController {
     private let labelStackView: UIStackView = UIStackView()
     private let mainLabel: UILabel = UILabel()
     private let subLabel: UILabel = UILabel()
+    private let popupImage: UIImageView = UIImageView()
     
     private let buttonStackView: UIStackView = UIStackView()
     private let leftButton: UIButton = UIButton()
     private let rightButton: UIButton = UIButton()
     private let centerButton: UIButton = UIButton()
+    private let bottomButton: UIButton = UIButton()
+    private let closeButton: UIButton = UIButton()
     
     // MARK: - Life Cycle
     
@@ -90,6 +98,33 @@ final class ToasterPopupViewController: UIViewController {
             self.popupType = .Confirmation
         }
     
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    init(mainText: String?,
+         subText: String?,
+         imageURL: String?,
+         centerButtonTitle: String,
+         bottomButtonTitle: String,
+         centerButtonHandler: ButtonAction?,
+         bottomButtonHandler: ButtonAction?,
+         closeButtonHandler: ButtonAction?) {
+        
+        self.mainText = mainText
+        self.subText = subText
+        self.imageURL = imageURL
+        self.centerButtonTitle = centerButtonTitle
+        self.bottomButtonTitle = bottomButtonTitle
+        self.centerButtonHandler = nil
+        self.bottomButtonHandler = nil
+        self.closeButtonHandler = nil
+
+        if bottomButtonTitle.isEmpty {
+            self.popupType = .Confirmation
+        } else {
+            self.popupType = .Limitation
+        }
+        
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -144,9 +179,13 @@ private extension ToasterPopupViewController {
             $0.font = .suitRegular(size: 16)
         }
         
+        popupImage.do {
+            $0.kf.setImage(with: URL(string: imageURL ?? ""))
+        }
+        
         buttonStackView.do {
-            $0.axis = .horizontal
-            $0.spacing = popupType == .Cancelable ? 10 : 0
+            $0.axis = popupType == .Limitation ? .vertical : .horizontal
+            $0.spacing = popupType == .Confirmation ? 0 : 10
         }
         
         leftButton.do {
@@ -172,33 +211,55 @@ private extension ToasterPopupViewController {
             $0.setTitleColor(.toasterWhite, for: .normal)
             $0.titleLabel?.font = .suitBold(size: 16)
         }
+        
+        bottomButton.do {
+            let attributedString = NSAttributedString(
+                string: bottomButtonTitle,
+                attributes: [
+                    .foregroundColor: UIColor.gray800,
+                    .font: UIFont.suitRegular(size: 14),
+                    .underlineStyle: NSUnderlineStyle.single.rawValue
+                ]
+            )
+            $0.setAttributedTitle(attributedString, for: .normal)
+        }
+        
+        closeButton.do {
+            $0.setImage(.icClose24, for: .normal)
+            $0.tintColor = .black850
+            $0.isHidden = popupType == .Limitation ? false : true
+        }
     }
     
     func setupHierarchy() {
-        view.addSubview(popupStackView)
-        popupStackView.addArrangedSubviews(labelStackView,
-                                           buttonStackView)
-        if mainText != nil {
-            labelStackView.addArrangedSubview(mainLabel)
-        }
-        if subText != nil {
-            labelStackView.addArrangedSubview(subLabel)
-        }
-        buttonStackView.addArrangedSubviews(leftButton,
-                                            rightButton)
+        view.addSubviews(popupStackView)
         
-        if popupType == .Cancelable {
-            buttonStackView.addArrangedSubviews(leftButton,
-                                                rightButton)
-        } else {
+        if mainText != nil { labelStackView.addArrangedSubview(mainLabel) }
+        if subText != nil { labelStackView.addArrangedSubview(subLabel) }
+        if imageURL != nil { labelStackView.addArrangedSubviews(popupImage) }
+                
+        switch popupType {
+        case .Cancelable:
+            buttonStackView.addArrangedSubviews(leftButton, rightButton)
+        case .Confirmation:
             buttonStackView.addArrangedSubviews(centerButton)
+        case .Limitation:
+            buttonStackView.addArrangedSubviews(centerButton, bottomButton)
         }
+        popupStackView.addArrangedSubviews(labelStackView, buttonStackView)
+        popupStackView.addSubview(closeButton)
     }
     
     func setupLayout() {
         popupStackView.snp.makeConstraints {
             $0.width.equalTo(300)
             $0.center.equalToSuperview()
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.trailing.equalToSuperview().inset(24)
+            $0.size.equalTo(20)
         }
         
         if popupType == .Cancelable {
@@ -221,13 +282,15 @@ private extension ToasterPopupViewController {
         leftButton.addTarget(self, action: #selector(leftButtonTapped), for: .touchUpInside)
         rightButton.addTarget(self, action: #selector(rightButtonTapped), for: .touchUpInside)
         centerButton.addTarget(self, action: #selector(centerButtonTapped), for: .touchUpInside)
+        bottomButton.addTarget(self, action: #selector(bottomButtonTapped), for: .touchUpInside)
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
     }
     
     @objc func leftButtonTapped() {
         if let leftButtonHandler {
             leftButtonHandler()
         } else {
-            cancleAction()
+            cancelAction()
         }
     }
     
@@ -235,7 +298,7 @@ private extension ToasterPopupViewController {
         if let rightButtonHandler {
             rightButtonHandler()
         } else {
-            cancleAction()
+            cancelAction()
         }
     }
     
@@ -243,11 +306,27 @@ private extension ToasterPopupViewController {
         if let centerButtonHandler {
             centerButtonHandler()
         } else {
-            cancleAction()
+            cancelAction()
         }
     }
     
-    func cancleAction() {
+    @objc func bottomButtonTapped() {
+        if let bottomButtonHandler {
+            bottomButtonHandler()
+        } else {
+            cancelAction()
+        }
+    }
+    
+    @objc func closeButtonTapped() {
+        if let closeButtonHandler {
+            closeButtonHandler()
+        } else {
+            cancelAction()
+        }
+    }
+    
+    func cancelAction() {
         dismiss(animated: false)
     }
 }

--- a/TOASTER-iOS/Global/Extensions/UIViewController+.swift
+++ b/TOASTER-iOS/Global/Extensions/UIViewController+.swift
@@ -65,6 +65,26 @@ extension UIViewController {
         present(popupViewController, animated: false)
     }
     
+    func showLimitationPopup(forMainText: String? = nil,
+                             forSubText: String? = nil,
+                             forImageURL: String? = nil,
+                             centerButtonTitle: String,
+                             bottomButtonTitle: String,
+                             centerButtonHandler: (() -> Void)? = nil,
+                             bottomButtonHandler: (() -> Void)? = nil,
+                             closeButtonHandler: (() -> Void)? = nil) {
+        let popupViewController = ToasterPopupViewController(mainText: forMainText,
+                                                             subText: forSubText,
+                                                             imageURL: forImageURL,
+                                                             centerButtonTitle: centerButtonTitle,
+                                                             bottomButtonTitle: bottomButtonTitle,
+                                                             centerButtonHandler: centerButtonHandler,
+                                                             bottomButtonHandler: bottomButtonHandler,
+                                                             closeButtonHandler: closeButtonHandler)
+        popupViewController.modalPresentationStyle = .overFullScreen
+        present(popupViewController, animated: false)
+    }
+    
     /// 토스트 메시지를 보여주는 메서드
     func showToastMessage(width: CGFloat,
                           status: ToastStatus,

--- a/TOASTER-iOS/Network/Base/BaseTargetType.swift
+++ b/TOASTER-iOS/Network/Base/BaseTargetType.swift
@@ -30,6 +30,7 @@ enum UtilPath: String {
     case clip = "category"
     case search = ""
     case timer = "timer"
+    case popup = "api/v2/popup"
 }
 
 protocol BaseTargetType: TargetType {

--- a/TOASTER-iOS/Network/Base/NetworkService.swift
+++ b/TOASTER-iOS/Network/Base/NetworkService.swift
@@ -19,4 +19,5 @@ final class NetworkService {
     let clipService: ClipAPIServiceProtocol = ClipAPIService()
     let searchService: SearchAPIServiceProtocol = SearchAPIService()
     let timerService: TimerAPIServiceProtocol = TimerAPIService()
+    let popupService: PopupAPIServiceProtocol = PopupAPIService()
 }

--- a/TOASTER-iOS/Network/Popup/DTO/GetPopupInfoResponseDTO.swift
+++ b/TOASTER-iOS/Network/Popup/DTO/GetPopupInfoResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  GetPopupInfoResponseDTO.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/23/24.
+//
+
+import Foundation
+
+struct GetPopupInfoResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let data: GetPopupInfoResponseData
+}
+
+struct GetPopupInfoResponseData: Codable {
+    let popupList: [PopupList]
+}
+
+struct PopupList: Codable {
+    let id: Int
+    let image, activeStartDate, activeEndDate, linkURL: String
+}

--- a/TOASTER-iOS/Network/Popup/DTO/GetPopupInfoResponseDTO.swift
+++ b/TOASTER-iOS/Network/Popup/DTO/GetPopupInfoResponseDTO.swift
@@ -19,5 +19,5 @@ struct GetPopupInfoResponseData: Codable {
 
 struct PopupList: Codable {
     let id: Int
-    let image, activeStartDate, activeEndDate, linkURL: String
+    let image, activeStartDate, activeEndDate, linkUrl: String
 }

--- a/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenRequestDTO.swift
+++ b/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PatchPopupHiddenRequestDTO.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/23/24.
+//
+
+import Foundation
+
+struct PatchPopupHiddenRequestDTO: Codable {
+    let popupID, hideDate: Int
+}

--- a/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenRequestDTO.swift
+++ b/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenRequestDTO.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct PatchPopupHiddenRequestDTO: Codable {
-    let popupID, hideDate: Int
+    let popupId, hideDate: Int
 }

--- a/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenResponseDTO.swift
+++ b/TOASTER-iOS/Network/Popup/DTO/PatchPopupHiddenResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  PatchPopupHiddenResponseDTO.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/23/24.
+//
+
+import Foundation
+
+struct PatchPopupHiddenResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let data: PatchPopupHiddenResponseData
+}
+
+struct PatchPopupHiddenResponseData: Codable {
+    let popupID: Int
+    let hideUntil: String
+}

--- a/TOASTER-iOS/Network/Popup/PopupAPIService.swift
+++ b/TOASTER-iOS/Network/Popup/PopupAPIService.swift
@@ -1,0 +1,53 @@
+//
+//  PopupAPIService.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/23/24.
+//
+
+import Foundation
+
+import Moya
+
+protocol PopupAPIServiceProtocol {
+    func getPopupInfo(completion: @escaping (NetworkResult<GetPopupInfoResponseDTO>) -> Void)
+    func patchEditPopupHidden(requestBody: PatchPopupHiddenRequestDTO,
+                              completion: @escaping (NetworkResult<PatchPopupHiddenResponseDTO>) -> Void)
+}
+
+final class PopupAPIService: BaseAPIService, PopupAPIServiceProtocol {
+    private let provider = MoyaProvider<PopupTargetType>.init(session: Session(interceptor: APIInterceptor.shared), plugins: [MoyaPlugin()])
+
+    func getPopupInfo(completion: @escaping (NetworkResult<GetPopupInfoResponseDTO>) -> Void) {
+        provider.request(.getPopupInfo) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<GetPopupInfoResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                print(networkResult.stateDescription)
+                completion(networkResult)
+            case .failure(let error):
+                if let response = error.response {
+                    let networkResult: NetworkResult<GetPopupInfoResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    completion(networkResult)
+                }
+            }
+        }
+    }
+    
+    func patchEditPopupHidden(requestBody: PatchPopupHiddenRequestDTO,
+                              completion: @escaping (NetworkResult<PatchPopupHiddenResponseDTO>) -> Void) {
+        provider.request(.patchEditPopupHidden(requestBody: requestBody)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<PatchPopupHiddenResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                print(networkResult.stateDescription)
+                completion(networkResult)
+            case .failure(let error):
+                if let response = error.response {
+                    let networkResult: NetworkResult<PatchPopupHiddenResponseDTO> = self.fetchNetworkResult(statusCode: response.statusCode, data: response.data)
+                    completion(networkResult)
+                }
+            }
+        }
+    }
+}

--- a/TOASTER-iOS/Network/Popup/PopupTargetType.swift
+++ b/TOASTER-iOS/Network/Popup/PopupTargetType.swift
@@ -1,0 +1,38 @@
+//
+//  PopupTargetType.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/23/24.
+//
+
+import Foundation
+
+import Moya
+
+enum PopupTargetType {
+    case getPopupInfo
+    case patchEditPopupHidden(requestBody: PatchPopupHiddenRequestDTO)
+}
+
+extension PopupTargetType: BaseTargetType {
+    var headerType: HeaderType { return .accessTokenHeader }
+    var utilPath: UtilPath { return .popup }
+    var pathParameter: String? { return .none }
+    var queryParameter: [String: Any]? { return .none }
+    
+    var requestBodyParameter: Codable? {
+        switch self {
+        case .patchEditPopupHidden(let body): return body
+        default: return .none
+        }
+    }
+    
+    var path: String { return utilPath.rawValue }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getPopupInfo: return .get
+        case .patchEditPopupHidden: return .patch
+        }
+    }
+}

--- a/TOASTER-iOS/Present/Home/Model/PopupInfoModel.swift
+++ b/TOASTER-iOS/Present/Home/Model/PopupInfoModel.swift
@@ -1,0 +1,16 @@
+//
+//  PopupInfoModel.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 9/24/24.
+//
+
+import Foundation
+
+struct PopupInfoModel {
+    let id: Int
+    let image: String
+    let activeStartDate: String
+    let activeEndDate: String
+    let linkURL: String
+}

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -26,7 +26,10 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         homeView.backgroundColor = .toasterBackground
-        setView()
+        setupHierarchy()
+        setupLayout()
+        createCollectionView()
+        setupDelegate()
         setupViewModel()
     }
     
@@ -37,6 +40,7 @@ final class HomeViewController: UIViewController {
         viewModel.fetchMainPageData()
         viewModel.fetchWeeklyLinkData()
         viewModel.fetchRecommendSiteData()
+        viewModel.getPopupInfoAPI()
     }
 }
 
@@ -101,9 +105,10 @@ extension HomeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.section {
         case 0:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCollectionViewCell.className,
-                                                                for: indexPath) as? MainCollectionViewCell else { return UICollectionViewCell() }
-            
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: MainCollectionViewCell.className,
+                for: indexPath
+            ) as? MainCollectionViewCell else { return UICollectionViewCell() }
             let model = viewModel.mainInfoList
             cell.bindData(forModel: model)
             cell.mainCollectionViewDelegate = self
@@ -111,12 +116,16 @@ extension HomeViewController: UICollectionViewDataSource {
         case 1:
             let lastIndex = viewModel.mainInfoList.mainCategoryListDto.count
             if indexPath.item == lastIndex && lastIndex < 4 {
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserClipEmptyCollectionViewCell.className,
-                                                                    for: indexPath) as? UserClipEmptyCollectionViewCell else { return UICollectionViewCell() }
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: UserClipEmptyCollectionViewCell.className,
+                    for: indexPath
+                ) as? UserClipEmptyCollectionViewCell else { return UICollectionViewCell() }
                 return cell
             } else {
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: UserClipCollectionViewCell.className,
-                                                                    for: indexPath) as? UserClipCollectionViewCell else { return UICollectionViewCell() }
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: UserClipCollectionViewCell.className,
+                    for: indexPath
+                ) as? UserClipCollectionViewCell else { return UICollectionViewCell() }
                 let model = viewModel.mainInfoList.mainCategoryListDto
                 if indexPath.item == 0 {
                     cell.bindData(forModel: model[indexPath.item],
@@ -128,16 +137,18 @@ extension HomeViewController: UICollectionViewDataSource {
                 return cell
             }
         case 2:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WeeklyLinkCollectionViewCell.className,
-                                                                for: indexPath) as? WeeklyLinkCollectionViewCell
-            else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: WeeklyLinkCollectionViewCell.className,
+                for: indexPath
+            ) as? WeeklyLinkCollectionViewCell else { return UICollectionViewCell() }
             let model = viewModel.weeklyLinkList
             cell.bindData(forModel: model[indexPath.item])
             return cell
         case 3:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WeeklyRecommendCollectionViewCell.className,
-                                                                for: indexPath) as? WeeklyRecommendCollectionViewCell
-            else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: WeeklyRecommendCollectionViewCell.className,
+                for: indexPath
+            ) as? WeeklyRecommendCollectionViewCell else { return UICollectionViewCell() }
             let model = viewModel.recommendSiteList
             cell.bindData(forModel: model[indexPath.item])
             return cell
@@ -151,12 +162,12 @@ extension HomeViewController: UICollectionViewDataSource {
                         viewForSupplementaryElementOfKind kind: String,
                         at indexPath: IndexPath) -> UICollectionReusableView {
         switch kind {
-            
-            // header
         case UICollectionView.elementKindSectionHeader:
-            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
-                                                                               withReuseIdentifier: HomeHeaderCollectionView.className,
-                                                                               for: indexPath) as? HomeHeaderCollectionView else { return UICollectionReusableView() }
+            guard let header = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: HomeHeaderCollectionView.className,
+                for: indexPath
+            ) as? HomeHeaderCollectionView else { return UICollectionReusableView() }
             switch indexPath.section {
             case 1:
                 let nickName = viewModel.mainInfoList.nickname
@@ -172,14 +183,14 @@ extension HomeViewController: UICollectionViewDataSource {
             }
             return header
             
-            // footer
         case UICollectionView.elementKindSectionFooter:
-            guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
-                                                                               withReuseIdentifier: HomeFooterCollectionView.className,
-                                                                               for: indexPath) as? HomeFooterCollectionView else { return UICollectionReusableView() }
+            guard let footer = collectionView.dequeueReusableSupplementaryView(
+                ofKind: kind,
+                withReuseIdentifier: HomeFooterCollectionView.className,
+                for: indexPath
+            ) as? HomeFooterCollectionView else { return UICollectionReusableView() }
             return footer
-        default:
-            return UICollectionReusableView()
+        default: return UICollectionReusableView()
         }
     }
     
@@ -251,7 +262,8 @@ private extension HomeViewController {
         viewModel.setupDataChangeAction(changeAction: reloadCollectionView,
                                         forUnAuthorizedAction: unAuthorizedAction,
                                         editAction: addClipAction,
-                                        moveAction: moveBottomAction)
+                                        moveAction: moveBottomAction,
+                                        popupAction: showPopupAction)
     }
     
     func reloadCollectionView(isHidden: Bool) {
@@ -283,6 +295,36 @@ private extension HomeViewController {
                                   message: StringLiterals.ToastMessage.completeAddClip)
         }
     }
+        
+    func showPopupAction(isShow: Bool) {
+        if isShow {
+            showLimitationPopup(
+                forMainText: "1분 설문조사 참여하고\n스타벅스 기프티콘 받기",
+                forSubText: "토스터 사용 피드백을 남겨주시면\n추첨을 통해 기프티콘을 드려요!",
+                forImageURL: "https://github.com/user-attachments/assets/753bcdee-fd2f-4fd4-a294-2f313f947d91",
+                centerButtonTitle: "참여하기",
+                bottomButtonTitle: "일주일간 보지 않기",
+                centerButtonHandler: {
+                    let nextVC = LinkWebViewController()
+                    nextVC.hidesBottomBarWhenPushed = true
+                    nextVC.setupDataBind(
+                        linkURL: self.viewModel.popupInfoList?[0].linkURL ?? "",
+                        isRead: true,
+                        id: 0
+                    )
+                    self.navigationController?.pushViewController(nextVC, animated: true)
+                },
+                // MARK: - popupId 부분 수정 필요
+                bottomButtonHandler: {
+                    self.viewModel.patchEditPopupHiddenAPI(popupId: 0, hideDate: 7)
+                },
+                // MARK: - popupId 부분 수정 필요
+                closeButtonHandler: {
+                    self.viewModel.patchEditPopupHiddenAPI(popupId: 0, hideDate: 1)
+                }
+            )
+        }
+    }
     
     func setupNavigationBar() {
         let type: ToasterNavigationType = ToasterNavigationType(hasBackButton: false,
@@ -300,13 +342,6 @@ private extension HomeViewController {
         let settingVC = SettingViewController()
         settingVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(settingVC, animated: true)
-    }
-    
-    func setView() {
-        setupHierarchy()
-        setupLayout()
-        createCollectionView()
-        setupDelegate()
     }
 }
 

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -298,29 +298,28 @@ private extension HomeViewController {
         
     func showPopupAction(isShow: Bool) {
         if isShow {
+            guard let popupId = viewModel.popupInfoList?.first?.id else { return }
             showLimitationPopup(
                 forMainText: "1분 설문조사 참여하고\n스타벅스 기프티콘 받기",
                 forSubText: "토스터 사용 피드백을 남겨주시면\n추첨을 통해 기프티콘을 드려요!",
-                forImageURL: "https://github.com/user-attachments/assets/753bcdee-fd2f-4fd4-a294-2f313f947d91",
+                forImageURL: viewModel.popupInfoList?.first?.image,
                 centerButtonTitle: "참여하기",
                 bottomButtonTitle: "일주일간 보지 않기",
                 centerButtonHandler: {
                     let nextVC = LinkWebViewController()
                     nextVC.hidesBottomBarWhenPushed = true
-                    nextVC.setupDataBind(
-                        linkURL: self.viewModel.popupInfoList?[0].linkURL ?? "",
-                        isRead: true,
-                        id: 0
-                    )
+                    nextVC.setupDataBind(linkURL: self.viewModel.popupInfoList?.first?.linkURL ?? "")
+                    self.viewModel.patchEditPopupHiddenAPI(popupId: popupId, hideDate: 1)
+                    self.dismiss(animated: false)
                     self.navigationController?.pushViewController(nextVC, animated: true)
                 },
-                // MARK: - popupId 부분 수정 필요
                 bottomButtonHandler: {
-                    self.viewModel.patchEditPopupHiddenAPI(popupId: 0, hideDate: 7)
+                    self.viewModel.patchEditPopupHiddenAPI(popupId: popupId, hideDate: 7)
+                    self.dismiss(animated: false)
                 },
-                // MARK: - popupId 부분 수정 필요
                 closeButtonHandler: {
-                    self.viewModel.patchEditPopupHiddenAPI(popupId: 0, hideDate: 1)
+                    self.viewModel.patchEditPopupHiddenAPI(popupId: popupId, hideDate: 1)
+                    self.dismiss(animated: false)
                 }
             )
         }

--- a/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
+++ b/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
@@ -57,9 +57,8 @@ final class HomeViewModel {
     
     private(set) var popupInfoList: [PopupInfoModel]? {
         didSet {
-            if let isEmpty = popupInfoList?.isEmpty {
-                dataChangeAction?(!isEmpty)
-            }
+            guard let isEmpty = popupInfoList?.isEmpty else { return }
+            showPopupAction?(!isEmpty)
         }
     }
 }
@@ -195,7 +194,7 @@ extension HomeViewModel {
                                                    image: data[idx].image,
                                                    activeStartDate: data[idx].activeStartDate,
                                                    activeEndDate: data[idx].activeEndDate,
-                                                   linkURL: data[idx].linkURL))
+                                                   linkURL: data[idx].linkUrl))
                     }
                     self.popupInfoList = list
                 }
@@ -209,12 +208,12 @@ extension HomeViewModel {
     func patchEditPopupHiddenAPI(popupId: Int, hideDate: Int) {
         NetworkService.shared.popupService.patchEditPopupHidden(
             requestBody: PatchPopupHiddenRequestDTO(
-                popupID: popupId,
+                popupId: popupId,
                 hideDate: hideDate
             )
         ) { result in
             switch result {
-            case .success(let response):
+            case .success:
                 self.popupInfoList?.removeAll()
             case .networkFail, .unAuthorized, .notFound:
                 self.unAuthorizedAction?()

--- a/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
+++ b/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,7 @@ final class HomeViewModel {
     private var dataChangeAction: DataChangeAction?
     private var dataEmptyAction: DataChangeAction?
     private var moveBottomAction: DataChangeAction?
+    private var showPopupAction: DataChangeAction?
     
     typealias NormalChangeAction = () -> Void
     private var unAuthorizedAction: NormalChangeAction?
@@ -31,22 +32,34 @@ final class HomeViewModel {
         }
     }
     
-    private(set) var weeklyLinkList: [WeeklyLinkModel] = [WeeklyLinkModel(toastId: 0,
-                                                             toastTitle: "",
-                                                             toastImg: "",
-                                                             toastLink: "")] {
+    private(set) var weeklyLinkList: [WeeklyLinkModel] = [
+        WeeklyLinkModel(toastId: 0,
+                        toastTitle: "",
+                        toastImg: "",
+                        toastLink: "")
+    ] {
         didSet {
             dataChangeAction?(!weeklyLinkList.isEmpty)
         }
     }
     
-    private(set) var recommendSiteList: [RecommendSiteModel] = [RecommendSiteModel(siteId: 0, 
-                                                                      siteTitle: nil ?? "",
-                                                                      siteUrl: nil ?? "",
-                                                                      siteImg: nil ?? "",
-                                                                      siteSub: nil ?? "")] {
+    private(set) var recommendSiteList: [RecommendSiteModel] = [
+        RecommendSiteModel(siteId: 0,
+                           siteTitle: nil ?? "",
+                           siteUrl: nil ?? "",
+                           siteImg: nil ?? "",
+                           siteSub: nil ?? "")
+    ] {
         didSet {
             dataChangeAction?(!recommendSiteList.isEmpty)
+        }
+    }
+    
+    private(set) var popupInfoList: [PopupInfoModel]? {
+        didSet {
+            if let isEmpty = popupInfoList?.isEmpty {
+                dataChangeAction?(!isEmpty)
+            }
         }
     }
 }
@@ -58,11 +71,13 @@ extension HomeViewModel {
     func setupDataChangeAction(changeAction: @escaping DataChangeAction,
                                forUnAuthorizedAction: @escaping NormalChangeAction,
                                editAction: @escaping NormalChangeAction,
-                               moveAction: @escaping DataChangeAction) {
+                               moveAction: @escaping DataChangeAction,
+                               popupAction: @escaping DataChangeAction) {
         dataChangeAction = changeAction
         unAuthorizedAction = forUnAuthorizedAction
         textFieldEditAction = editAction
         moveBottomAction = moveAction
+        showPopupAction = popupAction
     }
     
     func fetchMainPageData() {
@@ -162,6 +177,45 @@ extension HomeViewModel {
                     self.textFieldEditAction?()
                 }
                 self.fetchMainPageData()
+            case .networkFail, .unAuthorized, .notFound:
+                self.unAuthorizedAction?()
+            default: return
+            }
+        }
+    }
+    
+    func getPopupInfoAPI() {
+        NetworkService.shared.popupService.getPopupInfo { result in
+            switch result {
+            case .success(let response):
+                if let data = response?.data.popupList {
+                    var list: [PopupInfoModel] = []
+                    for idx in 0..<data.count {
+                        list.append(PopupInfoModel(id: data[idx].id,
+                                                   image: data[idx].image,
+                                                   activeStartDate: data[idx].activeStartDate,
+                                                   activeEndDate: data[idx].activeEndDate,
+                                                   linkURL: data[idx].linkURL))
+                    }
+                    self.popupInfoList = list
+                }
+            case .networkFail, .unAuthorized, .notFound:
+                self.unAuthorizedAction?()
+            default: return
+            }
+        }
+    }
+    
+    func patchEditPopupHiddenAPI(popupId: Int, hideDate: Int) {
+        NetworkService.shared.popupService.patchEditPopupHidden(
+            requestBody: PatchPopupHiddenRequestDTO(
+                popupID: popupId,
+                hideDate: hideDate
+            )
+        ) { result in
+            switch result {
+            case .success(let response):
+                self.popupInfoList?.removeAll()
             case .networkFail, .unAuthorized, .notFound:
                 self.unAuthorizedAction?()
             default: return


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #202 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
### 1. 업데이트 팝업 UI 구현
기존 팝업 Type에서는 하단 버튼이 1개/2개로만 구분되어 있어서,   
별도로 이번과 같이 버튼을 세로로 배치해야 하는 경우에 대해서 `.Limitation` case를 새롭게 추가했습니다.
https://github.com/Link-MIND/TOASTER-iOS/blob/7a23cf5f6b78537331d8458a8fea048f830dcbf7/TOASTER-iOS/Global/Components/ToasterPopup/ToasterPopupViewController.swift#L13-L17
|    구현 내용    |   화면   |  
| :---: | :----------: | 
| 팝업 | <img src = "https://github.com/user-attachments/assets/c5e883c3-e20d-420f-ab6a-9da9a2f9671b" width ="250"> | 

### 2. showLimitationPopup() 매서드 추가
UIViewController Extension에 해당 팝업 형태를 재사용할 수 있도록 `showLimitationPopup()` 메서드를 추가해줬습니다.
https://github.com/Link-MIND/TOASTER-iOS/blob/7a23cf5f6b78537331d8458a8fea048f830dcbf7/TOASTER-iOS/Global/Extensions/UIViewController%2B.swift#L68-L86

### 3. 팝업 로직
- `HomeVC`에 진입할 때, 팝업 GET API를 호출하도록 했습니다.
  - 외부 링크 붙여넣기 허용 경우 -> 바로 링크 저장 화면으로 넘어가 팝업 표출 x
  - 외부 링크 붙여넣기 허용안함 경우 -> 홈 화면으로 진입하기 때문에 팝업 표출 로직으로 진입
  
- 팝업 링크로 넘어가는 경우(설문조사 참여하기) -> 1일 이후에 다시 표출되도록 팝업 Patch 서버 호출 
- 상단 x 버튼 누른 경우(closeButton) -> 1일 이후에 다시 표출되도록 팝업 Patch 서버 호출 
- 하단 일주일간 보지 않기 버튼 누른 경우(bottomButton), 7일 이후에 다시 표출되도록 팝업 Patch 서버 호출 

<br>

## 🚨 확인 필요 내용
이번에 Xcode 16.0, macOS Sequoia 15.0 버전으로 업데이트하면서 새로운 파일을 생성하니까 아래와 같이 `project.pbxproj` 파일이 2개씩 저장되는 문제가 있더라구요..?

제가 임의로 하나를 지우고 커밋하면, 빌드가 안되는 문제가 있어서 한번씩 확인해주시면 감사하겠습니다..!
https://github.com/Link-MIND/TOASTER-iOS/blob/7a23cf5f6b78537331d8458a8fea048f830dcbf7/TOASTER-iOS.xcodeproj/project.pbxproj#L26-L35

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
