### PR TITLE
[Chore] #209 - 사파리 외에 다른 앱에서도 Share Extension 대응

### DIFF
--- a/ToasterShareExtension/Info.plist
+++ b/ToasterShareExtension/Info.plist
@@ -29,8 +29,10 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
-				<key>NSExtensionActivationSupportsURLWithMaxCount</key>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
 			</dict>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ToasterShareExtension/ShareViewController.swift
+++ b/ToasterShareExtension/ShareViewController.swift
@@ -198,13 +198,16 @@ private extension ShareViewController {
     // 웹 사이트 URL 를 받아올 수 있는 메서드
     func getUrl() {
         if let item = extensionContext?.inputItems.first as? NSExtensionItem,
-           let itemProvider = item.attachments?.first as? NSItemProvider,
-           itemProvider.hasItemConformingToTypeIdentifier("public.url") {
-            itemProvider.loadItem(forTypeIdentifier: "public.url", options: nil) { [weak self] (url, error) in
-                if let shareURL = url as? URL {
-                    self?.urlString = shareURL.absoluteString
-                } else {
-                    print("Error loading URL: \(error?.localizedDescription ?? "")")
+           let itemProviders = item.attachments {
+            itemProviders.forEach { itemProvider in
+                if itemProvider.hasItemConformingToTypeIdentifier("public.url") {
+                    itemProvider.loadItem(forTypeIdentifier: "public.url") { [weak self] (url, error) in
+                        if let shareURL = url as? URL {
+                            self?.urlString = shareURL.absoluteString
+                        } else {
+                            print("Error loading URL: \(error?.localizedDescription ?? "")")
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #209 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

### 1. NSExtensionActivationSupportsWebURLWithMaxCount
기존 쉐어 익스텐션 Info.plst에는 `NSExtensionActivationSupportsURLWithMaxCount`로 권한을 주고 있었는데, 해당 권한은 Safari의 URL에만 반응하고 있다는 문제를 발견했습니다.
`NSExtensionActivationSupportsWebURLWithMaxCount`이라는 속성으로 변경해 WebURL 기반으로 되어있는 타앱에서도 Share Sheet에 표출될 수 있도록 변경했습니다!

|    구현 내용    |  사파리   |  네이버  |  카카오  |
| :-------------: | :----------: | :----------: | :----------: |
| Share Sheet | <img src = "https://github.com/user-attachments/assets/6ffbe2ed-de92-400a-805c-0952fe5b0a0e" width ="250"> | <img src = "https://github.com/user-attachments/assets/c1718e12-2985-4323-89c8-bcf4acc4958d" width ="250"> | <img src = "https://github.com/user-attachments/assets/475a6c24-cde7-49cf-9bfb-c1aff03aef1d" width ="250"> |

### 2. NSExtensionActivationSupportsText
네이버 앱의 경우에는 WebURL이 아니라 Text로 넘어오더군요..
로그로 확인해보니 NSExtensionItem의 배열로 URL에 대한 내용(웹 페이지 타이틀)+URL 주소 형태로 넘어오고 있었기에   
단순히 WebURL로 받게되면 받아오지 못하던 문제가 있었습니다.
![스크린샷 2024-10-01 오후 3 20 01](https://github.com/user-attachments/assets/1eee25b3-53ff-43e2-acdb-fb38ed5f0977)

기존 Share Extension의 `getUrl()` 메서드를 NSExtensionItem 배열을 반복하면서 "public.url" 타입을 인식해서 처리할 수 있도록 코드를 수정했습니다!
https://github.com/Link-MIND/TOASTER-iOS/blob/36c7296bebc7726ca8a5675627b2da2782debc73/ToasterShareExtension/ShareViewController.swift#L199-L214

저 혼자서 Share Sheet가 동작하는 모든 상황을 대응할 수 없어서,   
타 앱에서 토스터를 Share Sheet로 사용해 링크 저장하는 경우 사례를 나중에 QA때 받아보는 것도 좋을 것 같습니다 ^__^

(어떤 앱은 URL만 넘기고, 어떤 앱은 URL을 Text로 넘기고, 네이버는 두개 다 넘기고 이런 식으로..)


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
