### PR TITLE
[Fix] #218 - 외부에서 받아온 url 형식 String 을 ViewModel 로 바인딩 코드 수정

### DIFF
--- a/ToasterShareExtension/ShareViewController.swift
+++ b/ToasterShareExtension/ShareViewController.swift
@@ -185,7 +185,7 @@ private extension ShareViewController {
                 if itemProvider.hasItemConformingToTypeIdentifier("public.url") {
                     itemProvider.loadItem(forTypeIdentifier: "public.url") { [weak self] (url, error) in
                         if let shareURL = url as? URL {
-                            self?.urlString = shareURL.absoluteString
+                            self?.shareViewModel.bindUrl(shareURL.absoluteString)
                         } else {
                             print("Error loading URL: \(error?.localizedDescription ?? "")")
                         }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #218 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- 외부에서 받아온 url 형식 String 을 ViewModel 로 바인딩 코드 작성


## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`ShareViewController`

``` swift
func getUrl() {
    self?.shareViewModel.bindUrl(shareURL.absoluteString)
}
```
fbab736 커밋을 보면 해당 값을 ViewModel 로 바인딩 하도록 구현해놓았지만
민재님께서 다른 앱에서도 사용할 수 있도록 변경해주신 부분을 Pull 받을 때 정확하게 확인하지 못하고 병합해버려 기존 코드가 존재하는 문제점이 있었습니다. 

pull 받고 동작하는지 확인을 했어야 하는데 확인하지 못한 점 죄송합니다.. 

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
