### PR TITLE
[Feat] #226 - 클립 이동 제한 로직 및 버튼 액션 추가

### DIFF
--- a/TOASTER-iOS/Present/DetailClip/View/Component/ChangeClipBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/ChangeClipBottomSheetView.swift
@@ -105,7 +105,15 @@ private extension ChangeClipBottomSheetView {
     }
     
     @objc func completeBottomuttonTapped(_ sender: UIButton) {
-        delegate?.completButtonTap()
+        completeBottomButton.loadingButtonTapped(
+            loadingTitle: "이동 중...",
+            loadingAnimationSize: 16,
+            task: { _ in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                    self.delegate?.completButtonTap()
+                }
+            }
+        )
     }
 }
 

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -165,8 +165,27 @@ private extension DetailClipViewController {
         output.clipData
             .receive(on: DispatchQueue.main)
             .sink { [weak self] clipData in
-                self?.changeClipBottomSheetView.dataSourceHandler = { clipData }
-                self?.changeClipBottomSheetView.reloadChangeClipBottom()
+                guard let self else { return }
+                
+                self.dismiss(animated: true) {
+                    // 이동할 클립이 2개 이상일 때 (전체클립 제외)
+                    if let data = clipData {
+                        self.dismiss(animated: true) {
+                            self.changeClipBottom.setupSheetPresentation(bottomHeight: self.changeClipViewModel.collectionViewHeight + 180)
+                            self.present(self.changeClipBottom, animated: true)
+                        }
+                        
+                        self.changeClipBottomSheetView.dataSourceHandler = { data }
+                        self.changeClipBottomSheetView.reloadChangeClipBottom()
+                        
+                    } else { // 현재 클립이 1개 존재할 때 (전체클립 제외)
+                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                            self.showToastMessage(width: 284,
+                                                  status: .warning,
+                                                  message: "이동할 클립을 하나 이상 생성해 주세요")
+                        }
+                    }
+                }
             }
             .store(in: cancelBag)
         
@@ -235,11 +254,6 @@ extension DetailClipViewController: UICollectionViewDataSource {
         // "클립이동" 클릭 시
         linkOptionBottomSheetView.setupChangeClipBottomSheetButtonAction {
             self.changeClipSubject.send()
-            
-            self.dismiss(animated: true) {
-                self.changeClipBottom.setupSheetPresentation(bottomHeight: self.changeClipViewModel.collectionViewHeight + 185)
-                self.present(self.changeClipBottom, animated: true)
-            }
         }
         
         // "삭제" 클릭 시

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/ChangeClipViewModel.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/ChangeClipViewModel.swift
@@ -22,7 +22,7 @@ final class ChangeClipViewModel: ViewModelType {
     }
     
     struct Output {
-        let clipData: AnyPublisher<[SelectClipModel], Never>
+        let clipData: AnyPublisher<[SelectClipModel]?, Never>
         let isCompleteButtonEnable: AnyPublisher<Bool, Never>
         let changeCategoryResult: AnyPublisher<Bool, Never>
     }
@@ -31,19 +31,25 @@ final class ChangeClipViewModel: ViewModelType {
         
         /// 클립이동  버튼이 눌렸을때 동작
         let clipDataPublisher = input.changeButtonTap
-            .flatMap { [weak self] _ -> AnyPublisher<[SelectClipModel], Never> in
+            .flatMap { [weak self] _ -> AnyPublisher<[SelectClipModel]?, Never> in
                 guard let self else {
                     return Just([]).eraseToAnyPublisher()
                 }
                 
                 return self.getAllCategoryAPI()
-                    .map { [weak self] result -> [SelectClipModel] in
+                    .map { [weak self] result -> [SelectClipModel]? in
                         guard let self = self else { return [] }
+                        
+                        // 2개 이하일 경우 nil 반환
+                        if result.count < 2 {
+                            return nil
+                        }
+                        
                         let sortedResult = self.sortCurrentCategoryToTop(result)
                         self.collectionViewHeight = self.calculateCollectionViewHeight(numberOfItems: sortedResult.count)
                         return sortedResult
                     }
-                    .catch { error -> AnyPublisher<[SelectClipModel], Never> in
+                    .catch { error -> AnyPublisher<[SelectClipModel]?, Never> in
                         print("Error: \(error)")
                         return Just([]).eraseToAnyPublisher()
                     }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #226 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

|   버튼 로딩 액션    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/1336eea6-0c22-4971-b9cd-6c90375380e4" width ="250"> | <img src = "https://github.com/user-attachments/assets/a2c7a95a-3550-428d-bde5-e18c07525a39" width ="250"> | <img src = "https://github.com/user-attachments/assets/32311e69-f619-4835-99e1-f0658add329c" width ="250"> |


|    클립 이동 제한   |  15 pro   |
| :----------: | :----------: |
|GIF|<img src = "https://github.com/user-attachments/assets/ec2b81c0-d210-4a23-982f-951d5464fd3d" width ="250">|

<br>

## 🖥️ 주요 코드 설명

<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
### 이동할 클립이 존재하지 않을때 

`ChangeClipViewModel`

```swift
let clipDataPublisher = input.changeButtonTap
    .flatMap { [weak self] _ -> AnyPublisher<[SelectClipModel]?, Never> in
        guard let self else {
            return Just([]).eraseToAnyPublisher()
        }
        
        return self.getAllCategoryAPI()
            .map { [weak self] result -> [SelectClipModel]? in
                guard let self = self else { return [] }
                
                // 2개 이하일 경우 nil 반환
                if result.count < 2 {
                    return nil
                }
                
                let sortedResult = self.sortCurrentCategoryToTop(result)
                self.collectionViewHeight = self.calculateCollectionViewHeight(numberOfItems: sortedResult.count)
                return sortedResult
            }
            .catch { error -> AnyPublisher<[SelectClipModel]?, Never> in
                print("Error: \(error)")
                return Just([]).eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()
    } .eraseToAnyPublisher()
```
링크 이동시에 이동할 클립이 존재하지 않을때의 로직을 구현했습니다.
이동할 클립을 해당 API 로 불러 오는데 개수가 2개 미만일 경우 nil 을 반환하도록 구현했습니다. 반환값도 옵셔널을 추가해주었습니다.

<br>

`DetailClipViewController`

``` swift
output.clipData
    .receive(on: DispatchQueue.main)
    .sink { [weak self] clipData in
        guard let self else { return }
        
        self.dismiss(animated: true) {
            // 이동할 클립이 2개 이상일 때 (전체클립 제외)
            if let data = clipData {
                self.dismiss(animated: true) {
                    self.changeClipBottom.setupSheetPresentation(bottomHeight: self.changeClipViewModel.collectionViewHeight + 180)
                    self.present(self.changeClipBottom, animated: true)
                }
                
                self.changeClipBottomSheetView.dataSourceHandler = { data }
                self.changeClipBottomSheetView.reloadChangeClipBottom()
                
            } else { // 현재 클립이 1개 존재할 때 (전체클립 제외)
                DispatchQueue.main.asyncAfter(deadline: .now()) {
                    self.showToastMessage(width: 284,
                                          status: .warning,
                                          message: "이동할 클립을 하나 이상 생성해 주세요")
                }
            }
        }
    }
    .store(in: cancelBag)
```

`DetailClipViewController` 에서 nil 값을 반환 받을 때 동작하는 로직을 추가했습니다. 
다음과 같이 ToastMessage 를 출력하도록 변경하였습니다.

<br>

### 버튼 액션 추가

``` swift
output.changeCategoryResult
    .receive(on: DispatchQueue.main)
    .sink { [weak self] result in
        guard let self else { return }
        if result == true {
            let categoryFilter = DetailCategoryFilter.allCases[viewModel.getViewModelProperty(dataType: .segmentIndex) as? Int ?? 0]
            
            self.changeClipBottom.dismiss(animated: true) {
                if self.viewModel.categoryId == 0 {
                    self.viewModel.getDetailAllCategoryAPI(filter: categoryFilter)
                } else {
                    self.viewModel.getDetailCategoryAPI(categoryID: self.viewModel.categoryId, filter: categoryFilter)
                }
            }

            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                self.showToastMessage(width: 152, 
                                      status: .check,
                                      message: "링크 이동 완료")
            }
        }
    }
    .store(in: cancelBag) completeButtonSubject
```
기존 로직은 VC 에서 `ChangeClipBottomSheetView` 의 버튼 액션을 Delegate 로 전달 받고 changeCategoryResult Publisher 로 이벤트를 전달하여 버튼 액션을 구현하고 있었습니다.

다만 고민이 됐던 부분은 버튼 액션을 처리하기 위해 task 탈출 클로저가 존재했는데 링크 이동 관련 로직은 MVVM (Input, output) 구조로 되어있어 API 를 호출하기 어려운 상황이였습니다.

<br>

``` swift
final class ChangeClipBottomSheetView: UIView {
    @objc func completeBottomuttonTapped(_ sender: UIButton) {
        completeBottomButton.loadingButtonTapped(
            loadingTitle: "이동 중...",
            loadingAnimationSize: 16,
            task: { _ in
                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
                    self.delegate?.completButtonTap()
                }
            }
        )
    }
}
```

하위 View 에서 ViewModel 과 Combine 을 사용하지 않는 것을 목표로 삼고 있어서 기존의 Delegate 를 살리고자 다음과 같이 구현했습니다.
Task 구문에서 직접 API 를 호출하지 않고 기존과 동일하게 VC 에서 처리할 수 있도록 구현했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
