### PR TITLE
[Fix] #229 - 복사, 붙여넣기 허용 알럿 관련 로직 수정

### DIFF
--- a/TOASTER-iOS/Application/SceneDelegate.swift
+++ b/TOASTER-iOS/Application/SceneDelegate.swift
@@ -63,25 +63,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         
-        if let pasteboardString = UIPasteboard.general.url {
+        if let pasteboardUrl = UIPasteboard.general.url {
             if appDelegate.isLogin {
                 guard let rootVC = window?.rootViewController as? ToasterNavigationController else { return }
                 let addLinkViewController = AddLinkViewController()
                 rootVC.pushViewController(addLinkViewController, animated: true)
-                addLinkViewController.embedURL(url: UIPasteboard.general.string ?? "")
+                addLinkViewController.embedURL(url: pasteboardUrl.absoluteString)
                                 
                 if let presentedVC = rootVC.presentedViewController {
                     presentedVC.dismiss(animated: false)
                 }
             }
         }
-        UIPasteboard.general.string = nil
     }
     
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
+        UIPasteboard.general.url = nil
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -74,6 +74,7 @@ extension AddLinkViewController {
         addLinkView.linkEmbedTextField.becomeFirstResponder()
         addLinkView.linkEmbedTextField.text = url   // 텍스트필드에 text 채우기
         viewModel.inputs.embedLinkText(url)         // 관리중 ViewModel에도 String 수정 -> UI 반영
+        UIPasteboard.general.url = nil
     }
 }
 

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -69,10 +69,11 @@ extension AddLinkViewController {
         delegate = forDelegate
     }
     
-    // 클립보드 붙여넣기 Alert -> 붙여넣기 허용 클릭 후 자동 링크 임베드를 위한 함수
+    /// 클립보드 붙여넣기 Alert -> 붙여넣기 허용 클릭 후 자동 링크 임베드를 위한 함수
     func embedURL(url: String) {
         addLinkView.linkEmbedTextField.becomeFirstResponder()
-        addLinkView.linkEmbedTextField.text = url
+        addLinkView.linkEmbedTextField.text = url   // 텍스트필드에 text 채우기
+        viewModel.inputs.embedLinkText(url)         // 관리중 ViewModel에도 String 수정 -> UI 반영
     }
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #229 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- 붙여넣기 "허용" 선택 시 기존 ViewModel에서 UI를 반영하는 로직이 빠져있어 추가했습니다~~
- 붙여넣기 "허용" 선택 시 -> `embedURL()` 부분에서 UIPasteboard 부분 초기화
- 붙여넣기 "허용 안 함" 선택 시 -> UIPasteboard에 해당 url 계속 남아있음 -> 직접 링크 저장 부분에서 LongPress로 붙여넣기 작업 수행 가능
- 백그라운드 진입 시 -> UIPasteboard 부분 초기화 -> 동일 붙여넣기 알럿 표시되지 않도록 함

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
