### PR TITLE
[Fix] #231 - 3차 스프린트 최종 QA 내용 반영

### DIFF
--- a/TOASTER-iOS/Present/DetailClip/View/Component/ChangeClipBottomSheetView.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/Component/ChangeClipBottomSheetView.swift
@@ -108,9 +108,10 @@ private extension ChangeClipBottomSheetView {
         completeBottomButton.loadingButtonTapped(
             loadingTitle: "이동 중...",
             loadingAnimationSize: 16,
-            task: { _ in
+            task: { completion in
                 DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
                     self.delegate?.completButtonTap()
+                    completion()
                 }
             }
         )

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/ChangeClipViewModel.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/ChangeClipViewModel.swift
@@ -64,7 +64,7 @@ final class ChangeClipViewModel: ViewModelType {
         
         /// 완료 버튼이 눌렸을때 동작
         let changeCategoryResult = input.completeButtonTap
-            .combineLatest(input.selectedClip) { _, selectedClip in
+            .zip(input.selectedClip) { _, selectedClip in
                 return selectedClip
             }
             .flatMap { [weak self] selectedClip -> AnyPublisher<Bool, Never> in

--- a/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/Cell/RemindSelectClipCollectionViewCell.swift
+++ b/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/Cell/RemindSelectClipCollectionViewCell.swift
@@ -80,6 +80,8 @@ extension RemindSelectClipCollectionViewCell {
     func configureCell(forModel: RemindClipModel, icon: UIImage, isRounded: Bool) {
         clipTitleLabel.text = forModel.title
         clipCountLabel.text = "\(forModel.clipCount)개"
+        clipTitleLabel.textColor = isSelected == true ? .toasterPrimary : .black850
+        clipCountLabel.textColor = isSelected == true ? .toasterPrimary : .gray600
         clipImageView.image = isSelected == true ? icon.withTintColor(.toasterPrimary) : icon
         self.isRounded = isRounded
     }

--- a/ToasterShareExtension/ShareViewController.swift
+++ b/ToasterShareExtension/ShareViewController.swift
@@ -58,6 +58,16 @@ class ShareViewController: UIViewController {
         super.viewDidAppear(animated)
         print("viewDidAppear View height: \(self.view.frame.size.height)")
         
+        clipSelectCollectionView.selectItem(
+            at: IndexPath(row: 0, section: 0),
+            animated: false,
+            scrollPosition: .top
+        )
+        collectionView(
+            clipSelectCollectionView,
+            didSelectItemAt: IndexPath(row: 0, section: 0)
+        )
+
         if isUseShareExtension {
             // 상단 Title 높이 + 데이터 개수 * cell 높이 + 하단 버튼 + SafeArea
             let calculateBottomSheetHeight = titleHeight + (viewModel.clipData.count) * 54 + 116


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #231 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
3차 스프린트 QA 내용을 반영했습니다.

- 한 뷰에서 클립 이동 2번째부터, 애니메이션 처리 / 바로 클릭되는 문제 해결
- Share Extension 최초 진입 시 전체 클립 선택된 상태 활성화

|    구현 내용    |   클립 이동 반복 버그 해결   |  익스텐션 첫 진입시 활성화  |  
| :-------------: | :----------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/e4b72c0c-af00-425c-a396-fd73df47f155" width ="250"> | <img src = "https://github.com/user-attachments/assets/67463ec5-23d3-44f4-9efa-4df7b03684e6" width ="250"> | 


## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
클립 이동 중복 방지와 관련해 두 개의 이슈가 있었습니다.
하나는, 애니메이션을 멈추는 비동기 completion 핸들러를 호출하지 않았던 것. 이래서 async-await 써야겠다 싶었네요.
https://github.com/Link-MIND/TOASTER-iOS/blob/349a0c6447d57fa1c99fd23f544859cb2f575a36/TOASTER-iOS/Present/DetailClip/View/Component/ChangeClipBottomSheetView.swift#L111-L114

또 다른 하나는 combineLatest 사용하던거 zip으로 해결했습니다. 
지금 상황에서는 셀을 선택하고 -> 버튼을 클릭하는 페어가 모두 갖춰져야만 네트워크 호출을 해야했습니다.
예전에 발생하던 문제는 버튼 클릭하는 이벤트가 방출되고 난 다음에, 셀만 클릭해도 결합이 되어 계속 publish가 되는 문제였습니다.

- `combineLatest` : "When/Or" 연산 -> Publisher 중 두 값이 한 곳에서라도 방출되면 단일 값으로 변환해 publish한다.
- `zip` : "When/And" 연산 -> 각 Publisher가 새 값을 방출할 때까지 기다렸다가 - 방출된 값들의 쌍이 모두 맞춰지면 단일 튜플로 변환해 publish 한다.
https://github.com/Link-MIND/TOASTER-iOS/blob/349a0c6447d57fa1c99fd23f544859cb2f575a36/TOASTER-iOS/Present/DetailClip/ViewModel/ChangeClipViewModel.swift#L66-L69

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
