### PR TITLE
[Refactor] #233 - 링크 저장 리팩토링 

### DIFF
--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -148,39 +148,39 @@ extension AddLinkViewController {
         let output = viewModel.transform(input, cancelBag: cancelBag)
         
         output.isClearButtonHidden
-            .sink { isHidden in
-                self.addLinkView.clearButton.isHidden = isHidden
+            .sink { [weak self] isHidden in
+                self?.addLinkView.clearButton.isHidden = isHidden
             }
             .store(in: cancelBag)
         
         output.isNextButtonEnabled
-            .sink { isEnabled in
-                self.addLinkView.nextTopButton.isEnabled = isEnabled
-                self.addLinkView.nextBottomButton.isEnabled = isEnabled
+            .sink { [weak self] isEnabled in
+                self?.addLinkView.nextTopButton.isEnabled = isEnabled
+                self?.addLinkView.nextBottomButton.isEnabled = isEnabled
             }
             .store(in: cancelBag)
         
         output.nextButtonBackgroundColor
-            .sink { color in
-                self.addLinkView.nextTopButton.backgroundColor = color
-                self.addLinkView.nextBottomButton.backgroundColor = color
+            .sink { [weak self] color in
+                self?.addLinkView.nextTopButton.backgroundColor = color
+                self?.addLinkView.nextBottomButton.backgroundColor = color
             }
             .store(in: cancelBag)
         
         output.linkEffectivenessMessage
-            .sink { message in
+            .sink { [weak self] message in
                 if let errorMessage = message {
-                    self.addLinkView.isValidLinkError(errorMessage)
+                    self?.addLinkView.isValidLinkError(errorMessage)
                 } else {
-                    self.addLinkView.resetError()
+                    self?.addLinkView.resetError()
                 }
             }
             .store(in: cancelBag)
         
         output.textFieldBorderColor
-            .sink { color in
-                self.addLinkView.linkEmbedTextField.layer.borderColor = color.cgColor
-                self.addLinkView.linkEmbedTextField.layer.borderWidth = 1
+            .sink { [weak self] color in
+                self?.addLinkView.linkEmbedTextField.layer.borderColor = color.cgColor
+                self?.addLinkView.linkEmbedTextField.layer.borderWidth = 1
             }
             .store(in: cancelBag)
     }

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -70,8 +70,13 @@ extension AddLinkViewController {
     /// 클립보드 붙여넣기 Alert -> 붙여넣기 허용 클릭 후 자동 링크 임베드를 위한 함수
     func embedURL(url: String) {
         addLinkView.linkEmbedTextField.becomeFirstResponder()
-        addLinkView.linkEmbedTextField.text = url   // 텍스트필드에 text 채우기
-        addLinkView.linkEmbedTextField.sendActions(for: .editingChanged)
+        addLinkView.linkEmbedTextField.text = url
+        viewModel.embedLinkText.send(url)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.addLinkView.linkEmbedTextField.sendActions(for: .editingChanged)
+        }
+        
         UIPasteboard.general.url = nil
     }
 }

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -141,8 +141,7 @@ extension AddLinkViewController {
             .eraseToAnyPublisher()
         
         let clearButtonTapped = addLinkView.clearButton.publisher(for: .touchUpInside)
-            .map { _ in }
-            .eraseToAnyPublisher()
+            .mapVoid()
         
         let input = AddLinkViewModel.Input(embedLinkText: embedLinkText, clearButtonTapped: clearButtonTapped)
         let output = viewModel.transform(input, cancelBag: cancelBag)

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -140,7 +140,11 @@ extension AddLinkViewController {
             .compactMap { [weak self] _ in self?.addLinkView.linkEmbedTextField.text ?? "" }
             .eraseToAnyPublisher()
         
-        let input = AddLinkViewModel.Input(embedLinkText: embedLinkText)
+        let clearButtonTapped = addLinkView.clearButton.publisher(for: .touchUpInside)
+            .map { _ in }
+            .eraseToAnyPublisher()
+        
+        let input = AddLinkViewModel.Input(embedLinkText: embedLinkText, clearButtonTapped: clearButtonTapped)
         let output = viewModel.transform(input, cancelBag: cancelBag)
         
         output.isClearButtonHidden

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -155,14 +155,9 @@ extension AddLinkViewController {
         output.isNextButtonEnabled
             .sink { [weak self] isEnabled in
                 self?.addLinkView.nextTopButton.isEnabled = isEnabled
+                self?.addLinkView.nextTopButton.backgroundColor = isEnabled ? .black850 : .gray200
                 self?.addLinkView.nextBottomButton.isEnabled = isEnabled
-            }
-            .store(in: cancelBag)
-        
-        output.nextButtonBackgroundColor
-            .sink { [weak self] color in
-                self?.addLinkView.nextTopButton.backgroundColor = color
-                self?.addLinkView.nextBottomButton.backgroundColor = color
+                self?.addLinkView.nextBottomButton.backgroundColor = isEnabled ? .black850 : .gray200
             }
             .store(in: cancelBag)
         
@@ -170,16 +165,12 @@ extension AddLinkViewController {
             .sink { [weak self] message in
                 if let errorMessage = message {
                     self?.addLinkView.isValidLinkError(errorMessage)
+                    self?.addLinkView.linkEmbedTextField.layer.borderColor = UIColor.toasterError.cgColor
+                    self?.addLinkView.linkEmbedTextField.layer.borderWidth = 1
                 } else {
                     self?.addLinkView.resetError()
+                    self?.addLinkView.linkEmbedTextField.layer.borderColor = UIColor.clear.cgColor
                 }
-            }
-            .store(in: cancelBag)
-        
-        output.textFieldBorderColor
-            .sink { [weak self] color in
-                self?.addLinkView.linkEmbedTextField.layer.borderColor = color.cgColor
-                self?.addLinkView.linkEmbedTextField.layer.borderWidth = 1
             }
             .store(in: cancelBag)
     }

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
@@ -20,7 +20,6 @@ final class AddLinkViewModel: ViewModelType {
     struct Output {
         let isClearButtonHidden = PassthroughSubject<Bool, Never>()
         let isNextButtonEnabled = CurrentValueSubject<Bool, Never>(false)
-        let nextButtonBackgroundColor = CurrentValueSubject<UIColor, Never>(.gray200)
         let textFieldBorderColor = PassthroughSubject<UIColor, Never>()
         let linkEffectivenessMessage = PassthroughSubject<String?, Never>()
     }
@@ -49,14 +48,6 @@ final class AddLinkViewModel: ViewModelType {
             .map { $0 && $1 }
             .sink { isEnabled in
                 output.isNextButtonEnabled.send(isEnabled)
-                output.nextButtonBackgroundColor.send(isEnabled ? .black850 : .gray200)
-            }
-            .store(in: cancelBag)
-        
-        isValid
-            .map { $0 ? .clear : UIColor.toasterError }
-            .sink { color in
-                output.textFieldBorderColor.send(color)
             }
             .store(in: cancelBag)
         

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
@@ -12,6 +12,8 @@ final class AddLinkViewModel: ViewModelType {
     
     private var cancelBag: CancelBag = CancelBag()
     
+    let embedLinkText = PassthroughSubject<String, Never>()
+    
     struct Input {
         let embedLinkText: AnyPublisher<String, Never>
         let clearButtonTapped: AnyPublisher<Void, Never>

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/ViewModel/AddLinkViewModel.swift
@@ -5,67 +5,69 @@
 //  Created by Gahyun Kim on 9/19/24.
 //
 
+import Combine
 import UIKit
 
-protocol AddLinkViewModelInputs {
-    func embedLinkText(_ text: String)
-}
-
-protocol AddLinkViewModelOutputs {
-    var isClearButtonHidden: Bool { get }
-    var isNextButtonEnabled: Bool { get }
-    var nextButtonBackgroundColor: UIColor { get }
-    var textFieldBorderColor: UIColor { get }
-    var linkEffectivenessMessage: String? { get }
-}
-
-protocol AddLinkViewModelType {
-    var inputs: AddLinkViewModelInputs { get }
-    var outputs: AddLinkViewModelOutputs { get }
-}
-
-final class AddLinkViewModel: AddLinkViewModelType, AddLinkViewModelInputs, AddLinkViewModelOutputs {
+final class AddLinkViewModel: ViewModelType {
     
-    // Input
-    private var embedLink: String = "" {
-        didSet {
-            updateOutputs()
-        }
+    private var cancelBag: CancelBag = CancelBag()
+    
+    struct Input {
+        let embedLinkText: AnyPublisher<String, Never>
     }
     
-    // Output
-    var isClearButtonHidden: Bool
-    var isNextButtonEnabled: Bool
-    var nextButtonBackgroundColor: UIColor
-    var textFieldBorderColor: UIColor
-    var linkEffectivenessMessage: String?
-    
-    init() {
-        self.isClearButtonHidden = true
-        self.isNextButtonEnabled = false
-        self.nextButtonBackgroundColor = .gray200
-        self.textFieldBorderColor = .clear
-        self.linkEffectivenessMessage = nil
+    struct Output {
+        let isClearButtonHidden = PassthroughSubject<Bool, Never>()
+        let isNextButtonEnabled = CurrentValueSubject<Bool, Never>(false)
+        let nextButtonBackgroundColor = CurrentValueSubject<UIColor, Never>(.gray200)
+        let textFieldBorderColor = PassthroughSubject<UIColor, Never>()
+        let linkEffectivenessMessage = PassthroughSubject<String?, Never>()
     }
     
-    func embedLinkText(_ text: String) {
-        embedLink = text
+    func transform(_ input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        
+        input.embedLinkText
+            .map { $0.isEmpty }
+            .sink { isHidden in
+                output.isClearButtonHidden.send(isHidden)
+            }
+            .store(in: cancelBag)
+        
+        let isValid = input.embedLinkText
+            .map { self.isValidURL($0) }
+            .share()
+            .eraseToAnyPublisher()
+        
+        isValid
+            .combineLatest(input.embedLinkText.map { !$0.isEmpty })
+            .map { $0 && $1 }
+            .sink { isEnabled in
+                print("활성화 유무 : ", isEnabled)
+                output.isNextButtonEnabled.send(isEnabled)
+                output.nextButtonBackgroundColor.send(isEnabled ? .black850 : .gray200)
+            }
+            .store(in: cancelBag)
+        
+        isValid
+            .map { $0 ? .clear : UIColor.toasterError }
+            .sink { color in
+                output.textFieldBorderColor.send(color)
+            }
+            .store(in: cancelBag)
+        
+        input.embedLinkText
+            .map { $0.isEmpty ? "링크를 입력해주세요" : (self.isValidURL($0) ? nil : "유효하지 않은 형식의 링크입니다. " ) }
+            .sink { message in
+                output.linkEffectivenessMessage.send(message)
+            }
+            .store(in: cancelBag)
+        
+        return output
     }
-    
-    var inputs: AddLinkViewModelInputs { return self }
-    var outputs: AddLinkViewModelOutputs { return self }
 }
 
 private extension AddLinkViewModel {
-    func updateOutputs() {
-        let isValid = isValidURL(embedLink)
-        isClearButtonHidden = embedLink.isEmpty
-        isNextButtonEnabled = !embedLink.isEmpty && isValid
-        nextButtonBackgroundColor = isNextButtonEnabled ? .black850 : .gray200
-        textFieldBorderColor = isValid ? .clear : UIColor.toasterError
-        linkEffectivenessMessage = isValid ? nil : (embedLink.isEmpty ? "링크를 입력해주세요" : "유효하지 않은 형식의 링크입니다.")
-    }
-    
     func isValidURL(_ urlString: String) -> Bool {
         if (urlString.prefix(8) == "https://") || (urlString.prefix(7) == "http://") {
             return true


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #233 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- 링크 저장 기능에서 타이머 삭제 후 Combine으로 리팩토링함
- 처음 써보는거라,,, 조언 부탁드립니다 

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`AddLinkViewModel `
- clearButton을 클릭했을때 textField 상태 처리를 하지 못하고 있는 것 같아서 input에 추가한 후 기존의 임베딩된 텍스트와 빈 문자열을 병합하는 방법을 사용했습니다 
- 굳이 Input에 퍼블리셔를 추가하지 않고 transform 안에서 연산자로 처리할 수 있는 방법이 있을까요...?? 있다면 알려주세야...
```swift
 struct Input {
        let embedLinkText: AnyPublisher<String, Never>
        let clearButtonTapped: AnyPublisher<Void, Never>
    }
```
```swift
let inputText = input.embedLinkText
            .merge(with: input.clearButtonTapped.map { "" })
            .eraseToAnyPublisher()
       
```


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
