### PR TITLE
[Refactor] #235 - ClipVC MVVM 코드 리팩토링

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		3972155B2CA8DB1A009DF1F9 /* Publisher+UIGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3972155A2CA8DB1A009DF1F9 /* Publisher+UIGesture.swift */; };
 		3972155D2CA9007B009DF1F9 /* Publisher+UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3972155C2CA9007B009DF1F9 /* Publisher+UIBarButtonItem.swift */; };
 		397586EC2CAA312C004FB095 /* Publisher+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397586EB2CAA312C004FB095 /* Publisher+Driver.swift */; };
+		39788C762CFF2A1300956A92 /* Publisher+Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39788C752CFF2A1300956A92 /* Publisher+Operator.swift */; };
+		39788C772CFF2A1300956A92 /* Publisher+Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39788C752CFF2A1300956A92 /* Publisher+Operator.swift */; };
 		398ACFDC2B5E77FA00D5EE77 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */; };
 		398BE7F32B456367001595E0 /* ToasterToastMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */; };
 		398BE7F62B456AF9001595E0 /* BottomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398BE7F52B456AF9001595E0 /* BottomType.swift */; };
@@ -384,6 +386,7 @@
 		3972155A2CA8DB1A009DF1F9 /* Publisher+UIGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+UIGesture.swift"; sourceTree = "<group>"; };
 		3972155C2CA9007B009DF1F9 /* Publisher+UIBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+UIBarButtonItem.swift"; sourceTree = "<group>"; };
 		397586EB2CAA312C004FB095 /* Publisher+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Driver.swift"; sourceTree = "<group>"; };
+		39788C752CFF2A1300956A92 /* Publisher+Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Operator.swift"; sourceTree = "<group>"; };
 		398ACFDB2B5E77FA00D5EE77 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		398BE7F22B456367001595E0 /* ToasterToastMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToasterToastMessageView.swift; sourceTree = "<group>"; };
 		398BE7F52B456AF9001595E0 /* BottomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomType.swift; sourceTree = "<group>"; };
@@ -745,6 +748,7 @@
 				3972155A2CA8DB1A009DF1F9 /* Publisher+UIGesture.swift */,
 				3972155C2CA9007B009DF1F9 /* Publisher+UIBarButtonItem.swift */,
 				3F82C3202CADA19300492EEE /* Publisher+UIButton.swift */,
+				39788C752CFF2A1300956A92 /* Publisher+Operator.swift */,
 			);
 			path = "Combine+";
 			sourceTree = "<group>";
@@ -1952,6 +1956,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				39788C772CFF2A1300956A92 /* Publisher+Operator.swift in Sources */,
 				3F3ED28A2BA1A456004E79F0 /* AuthTargetType.swift in Sources */,
 				396DCDFD2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
 				3F82C3222CADA1EF00492EEE /* Publisher+UIButton.swift in Sources */,
@@ -2198,6 +2203,7 @@
 				6BE6D9E62B4EA499008B06FA /* RemindCollectionHeaderView.swift in Sources */,
 				6BE6DA5F2B50B734008B06FA /* ClipTargetType.swift in Sources */,
 				3F2FA17B2B4928A200EDBF95 /* LoginError.swift in Sources */,
+				39788C762CFF2A1300956A92 /* Publisher+Operator.swift in Sources */,
 				6BE6DA7E2B54572B008B06FA /* ToasterAPIService.swift in Sources */,
 				830517A72B4D7225009FFB60 /* HomeView.swift in Sources */,
 				6B0E85D92B564913001BC15F /* RemindTimerAddViewModel.swift in Sources */,

--- a/TOASTER-iOS/Global/Extensions/Combine+/Publisher+Operator.swift
+++ b/TOASTER-iOS/Global/Extensions/Combine+/Publisher+Operator.swift
@@ -1,0 +1,33 @@
+//
+//  Publisher+Operator.swift
+//  TOASTER-iOS
+//
+//  Created by 민 on 12/3/24.
+//
+
+import Combine
+import Foundation
+
+public extension Publisher {
+    
+    /**
+     `networkFlatMap`은 네트워크 함수 호출 시
+     `flatMap` 연산을 수행하면서, 메모리 누수 방지와 에러 처리를 위한 반복 코드 사용을 줄이기 위한 커스텀 Operator입니다.
+     */
+    func networkFlatMap<SelfPublisher: AnyObject, NewPublisher: Publisher>(
+        _ weakSelf: SelfPublisher?,
+        _ firstTransform: @escaping (SelfPublisher, Output) -> NewPublisher,
+        _ secondTransform: @escaping (Error) -> AnyPublisher<NewPublisher.Output, Never> = { _ in
+            Empty().eraseToAnyPublisher()
+        }
+    ) -> AnyPublisher<NewPublisher.Output, Failure> {
+        
+        self.flatMap { [weak weakSelf] output -> AnyPublisher<NewPublisher.Output, Never> in
+            guard let weakSelf else { return Empty().eraseToAnyPublisher() }
+            return firstTransform(weakSelf, output)
+                .catch { secondTransform($0) }
+                .eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -184,9 +184,6 @@ extension AddLinkViewController {
 extension AddLinkViewController: SaveLinkButtonDelegate {
     func saveLinkButtonTapped() {
         delegate?.changeTabBarIndex()
-        navigationController?.showToastMessage(width: 157,
-                                               status: .check,
-                                               message: "링크 저장 완료!")
     }
     
     func cancleLinkButtonTapped() {

--- a/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
@@ -46,6 +46,8 @@ final class SelectClipViewModel: ViewModelType {
             }.store(in: cancelBag)
         
         input.clipNameChanged
+            .debounce(for: 0.2, scheduler: RunLoop.main)
+            .removeDuplicates()
             .networkFlatMap(self) { context, clipTitle in
                 context.getCheckCategoryAPI(categoryTitle: clipTitle)
             }

--- a/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
@@ -5,121 +5,175 @@
 //  Created by Gahyun Kim on 2024/02/27.
 //
 
-import Foundation
+import Combine
+import UIKit
 
-final class SelectClipViewModel {
+final class SelectClipViewModel: ViewModelType {
     
-    // MARK: - Properties
+    private var cancelBag = CancelBag()
+    var selectedClip: [RemindClipModel] = []
     
-    typealias DataChangeAction = (Bool) -> Void
-    private var dataChangeAction: DataChangeAction?
-    private var dataEmptyAction: DataChangeAction?
-    private var moveBottomAction: DataChangeAction?
+    // MARK: - Input State
     
-    typealias NormalChangeAction = () -> Void
-    private var unAuthorizedAction: NormalChangeAction?
-    private var textFieldEditAction: NormalChangeAction?
-    private var saveLinkAction: NormalChangeAction?
-    private var saveFailAction: NormalChangeAction?
-    
-    // MARK: - Data
-    
-    private(set) var selectedClip: [RemindClipModel] = [] {
-        didSet {
-            dataChangeAction?(!selectedClip.isEmpty)
-        }
+    struct Input {
+        let requestClipList: Driver<Void>
+        let clipNameChanged: Driver<String>
+        let addClipButtonTapped: Driver<String>
+        let completeButtonTapped: Driver<(String, Int?)>
     }
     
-    init() {
-        fetchClipData()
+    // MARK: - Output State
+    
+    struct Output {
+        let needToReload = PassthroughSubject<Void, Never>()
+        let duplicateClipName = PassthroughSubject<Bool, Never>()
+        let addClipResult = PassthroughSubject<Bool, Never>()
+        let saveLinkResult = PassthroughSubject<Bool, Never>()
+    }
+    
+    // MARK: - Method
+    
+    func transform(_ input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        
+        input.requestClipList
+            .flatMap { [weak self] _ -> AnyPublisher<[RemindClipModel], Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.fetchClipData()
+                    .catch { _ -> AnyPublisher<[RemindClipModel], Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }.eraseToAnyPublisher()
+            }
+            .sink { [weak self] clipDataList in
+                self?.selectedClip = clipDataList
+                output.needToReload.send()
+            }.store(in: cancelBag)
+        
+        input.clipNameChanged
+            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.getCheckCategoryAPI(categoryTitle: clipTitle)
+                    .catch { _ -> AnyPublisher<Bool, Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .sink { isDuplicate in
+                output.duplicateClipName.send(isDuplicate)
+            }.store(in: cancelBag)
+        
+        input.addClipButtonTapped
+            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.postAddCategoryAPI(requestBody: clipTitle)
+                    .catch { _ -> AnyPublisher<Bool, Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .sink { isSuccess in
+                output.addClipResult.send(isSuccess)
+                if isSuccess {
+                    output.needToReload.send()
+                }
+            }.store(in: cancelBag)
+        
+        input.completeButtonTapped
+            .flatMap { [weak self] (url, category) -> AnyPublisher<Bool, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.postSaveLink(url: url, category: category)
+                    .catch { _ -> AnyPublisher<Bool, Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }.eraseToAnyPublisher()
+            }
+            .sink { result in
+                output.saveLinkResult.send(result)
+            }.store(in: cancelBag)
+        
+        return output
     }
 }
 
-// MARK: - extension
+// MARK: - Network
 
-extension SelectClipViewModel {
-    func setupDataChangeAction(changeAction: @escaping DataChangeAction,
-                               forUnAuthorizedAction: @escaping NormalChangeAction,
-                               editAction: @escaping NormalChangeAction,
-                               moveAction: @escaping DataChangeAction,
-                               saveAction: @escaping NormalChangeAction,
-                               failAction: @escaping NormalChangeAction) {
-        dataChangeAction = changeAction
-        unAuthorizedAction = forUnAuthorizedAction
-        textFieldEditAction = editAction
-        moveBottomAction = moveAction
-        saveLinkAction = saveAction
-        saveFailAction = failAction
-    }
-    
-    // 임베드한 링크, 선택한 클립 id - POST
-    func postSaveLink(url: String, category: Int?) {
-        let request = PostSaveLinkRequestDTO(linkUrl: url,
-                                             categoryId: category)
-        NetworkService.shared.toastService.postSaveLink(requestBody: request) { result in
-            switch result {
-            case .success:
-                self.saveLinkAction?()
-            case .networkFail, .unAuthorized, .notFound:
-                self.unAuthorizedAction?()
-            case .badRequest, .serverErr:
-                self.saveFailAction?()
-            default:
-                return
-            }
-        }
-    }
-    
-    // 클립 정보 - GET
-    func fetchClipData() {
-        NetworkService.shared.clipService.getAllCategory { result in
-            switch result {
-            case .success(let response):
-                var clipDataList: [RemindClipModel] = [RemindClipModel(id: nil,
-                                                                       title: "전체 클립",
-                                                                       clipCount: response?.data.toastNumberInEntire ?? 0)]
-                response?.data.categories.forEach {
-                    let clipData = RemindClipModel(id: $0.categoryId,
-                                                   title: $0.categoryTitle,
-                                                   clipCount: $0.toastNum)
-                    clipDataList.append(clipData)
+private extension SelectClipViewModel {
+    func postSaveLink(url: String, category: Int?) -> AnyPublisher<Bool, Error> {
+        return Future<Bool, Error> { promise in
+            let request = PostSaveLinkRequestDTO(linkUrl: url, categoryId: category)
+            NetworkService.shared.toastService.postSaveLink(requestBody: request) { result in
+                switch result {
+                case .success:
+                    promise(.success(true))
+                case .badRequest, .serverErr:
+                    promise(.success(false))
+                case .networkFail, .unAuthorized, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
                 }
-                self.selectedClip = clipDataList
-            case .networkFail, .unAuthorized, .notFound:
-                self.unAuthorizedAction?()
-            default: break
             }
-        }
+        }.eraseToAnyPublisher()
     }
     
-    func postAddCategoryAPI(requestBody: String) {
-        NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
-            switch result {
-            case .success:
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.textFieldEditAction?()
-                }
-                self.fetchClipData()
-            case .networkFail, .unAuthorized, .notFound:
-                self.unAuthorizedAction?()
-            default: return
-            }
-        }
-    }
-    
-    func getCheckCategoryAPI(categoryTitle: String) {
-        NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
-            switch result {
-            case .success(let response):
-                if let data = response?.data.isDupicated {
-                    if categoryTitle.count != 16 {
-                        self.moveBottomAction?(data)
+    func fetchClipData() -> AnyPublisher<[RemindClipModel], Error> {
+        return Future<[RemindClipModel], Error> { promise in
+            NetworkService.shared.clipService.getAllCategory { result in
+                switch result {
+                case .success(let response):
+                    var clipDataList: [RemindClipModel] = [
+                        RemindClipModel(
+                            id: nil,
+                            title: "전체 클립",
+                            clipCount: response?.data.toastNumberInEntire ?? 0
+                        )
+                    ]
+                    response?.data.categories.forEach {
+                        let clipData = RemindClipModel(
+                            id: $0.categoryId,
+                            title: $0.categoryTitle,
+                            clipCount: $0.toastNum
+                        )
+                        clipDataList.append(clipData)
                     }
+                    promise(.success(clipDataList))
+                case .networkFail, .unAuthorized, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
                 }
-            case .networkFail, .unAuthorized, .notFound:
-                self.unAuthorizedAction?()
-            default: return
             }
-        }
+        }.eraseToAnyPublisher()
+    }
+    
+    func getCheckCategoryAPI(categoryTitle: String) -> AnyPublisher<Bool, Error> {
+        return Future<Bool, Error> { promise in
+            NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
+                switch result {
+                case .success(let response):
+                    if let data = response?.data.isDupicated, categoryTitle.count < 16 {
+                        promise(.success(data))
+                    }
+                case .unAuthorized, .networkFail, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func postAddCategoryAPI(requestBody: String) -> AnyPublisher<Bool, Error> {
+        return Future<Bool, Error> { promise in
+            NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
+                switch result {
+                case .success:
+                    promise(.success(true))
+                case .unAuthorized, .networkFail, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
+                }
+            }
+        }.eraseToAnyPublisher()
     }
 }

--- a/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
+++ b/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
@@ -11,10 +11,10 @@ import SnapKit
 import Then
 
 protocol AddClipBottomSheetViewDelegate: AnyObject {
-    func dismissButtonTapped(title: String)
+    // func dismissButtonTapped(title: String)
     func addHeightBottom()
     func minusHeightBottom()
-    func callCheckAPI(text: String)
+    // func callCheckAPI(text: String)
 }
 
 final class AddClipBottomSheetView: UIView {
@@ -54,6 +54,10 @@ final class AddClipBottomSheetView: UIView {
     private let addClipButton = UIButton()
     private let errorMessage = UILabel()
     private let clearButton = UIButton()
+    
+    lazy var textFieldValueChanged = NotificationCenter.default
+        .publisher(for: UITextField.textDidChangeNotification, object: self.addClipTextField)
+    lazy var addClipButtonTap = addClipButton.publisher(for: .touchUpInside)
     
     // MARK: - Life Cycles
     
@@ -123,7 +127,7 @@ private extension AddClipBottomSheetView {
             $0.setTitle(StringLiterals.Button.okay, for: .normal)
             $0.setTitleColor(.toasterWhite, for: .normal)
             $0.titleLabel?.font = .suitBold(size: 16)
-            $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+            // $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         }
         
         errorMessage.do {
@@ -216,7 +220,7 @@ private extension AddClipBottomSheetView {
     func startTimer() {
         timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
             if let urlText = self?.addClipTextField.text {
-                self?.addClipBottomSheetViewDelegate?.callCheckAPI(text: urlText)
+                // self?.addClipBottomSheetViewDelegate?.callCheckAPI(text: urlText)
             }
         }
     }
@@ -227,10 +231,10 @@ private extension AddClipBottomSheetView {
         startTimer()
     }
     
-    @objc
-    func buttonTapped() {
-        addClipBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
-    }
+//    @objc
+//    func buttonTapped() {
+//        addClipBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
+//    }
     
     @objc
     func clearButtonTapped() {

--- a/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
+++ b/TOASTER-iOS/Present/Clip/View/Component/AddClipBottomSheetView.swift
@@ -11,10 +11,8 @@ import SnapKit
 import Then
 
 protocol AddClipBottomSheetViewDelegate: AnyObject {
-    // func dismissButtonTapped(title: String)
     func addHeightBottom()
     func minusHeightBottom()
-    // func callCheckAPI(text: String)
 }
 
 final class AddClipBottomSheetView: UIView {
@@ -23,7 +21,6 @@ final class AddClipBottomSheetView: UIView {
     
     weak var addClipBottomSheetViewDelegate: AddClipBottomSheetViewDelegate?
     
-    private var timer: Timer?
     private var isButtonClicked: Bool = false {
         didSet {
             setupButtonColor()
@@ -50,7 +47,7 @@ final class AddClipBottomSheetView: UIView {
     
     // MARK: - UI Components
     
-    private let addClipTextField = UITextField()
+    private(set) var addClipTextField = UITextField()
     private let addClipButton = UIButton()
     private let errorMessage = UILabel()
     private let clearButton = UIButton()
@@ -127,7 +124,6 @@ private extension AddClipBottomSheetView {
             $0.setTitle(StringLiterals.Button.okay, for: .normal)
             $0.setTitleColor(.toasterWhite, for: .normal)
             $0.titleLabel?.font = .suitBold(size: 16)
-            // $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         }
         
         errorMessage.do {
@@ -217,25 +213,6 @@ private extension AddClipBottomSheetView {
         }
     }
     
-    func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
-            if let urlText = self?.addClipTextField.text {
-                // self?.addClipBottomSheetViewDelegate?.callCheckAPI(text: urlText)
-            }
-        }
-    }
-    
-    /// 타이머 재시작
-    func restartTimer() {
-        timer?.invalidate()
-        startTimer()
-    }
-    
-//    @objc
-//    func buttonTapped() {
-//        addClipBottomSheetViewDelegate?.dismissButtonTapped(title: addClipTextField.text ?? "")
-//    }
-    
     @objc
     func clearButtonTapped() {
         resetTextField()
@@ -246,7 +223,6 @@ private extension AddClipBottomSheetView {
 
 extension AddClipBottomSheetView: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        restartTimer()
         let newText = (textField.text as NSString?)?.replacingCharacters(in: range, with: string) ?? string
         let currentText = textField.text ?? ""
         let maxLength = 16
@@ -254,7 +230,6 @@ extension AddClipBottomSheetView: UITextFieldDelegate {
         // 길이가 16에서 15로 돌아갈 때
         if currentText.count == maxLength && newText.count == 15 {
             addClipBottomSheetViewDelegate?.minusHeightBottom()
-            restartTimer()
         }
         return newText.count <= maxLength
     }

--- a/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
+++ b/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
@@ -5,89 +5,222 @@
 //  Created by 민 on 2/7/24.
 //
 
-import Foundation
+import Combine
+import UIKit
 
-final class ClipViewModel: NSObject {
+final class ClipViewModel: ViewModelType {
     
-    // MARK: - Properties
+    private var cancelBag = CancelBag()
+    var clipList: ClipModel = ClipModel(allClipToastCount: 0, clips: [])
     
-    typealias DataChangeAction = (Bool) -> Void
-    private var dataChangeAction: DataChangeAction?
-    private var moveBottomAction: DataChangeAction?
+    // MARK: - Input State
     
-    typealias NormalChangeAction = () -> Void
-    private var unAuthorizedAction: NormalChangeAction?
-    private var textFieldEditAction: NormalChangeAction?
+    struct Input {
+        let viewDidLoad: Driver<Void>
+        let clipNameChanged: Driver<String>
+        let addClipButtonTapped: Driver<String>
+    }
+    
+    // MARK: - Output State
+    
+    struct Output {
+        let needToReload = PassthroughSubject<Void, Never>()
+        let addClipResult = PassthroughSubject<Bool, Never>()
+        let duplicateClipName = PassthroughSubject<Bool, Never>()
+    }
+    
+    // MARK: - Method
+    
+    func transform(_ input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
         
-    // MARK: - Data
-    
-    private(set) var clipList: ClipModel = ClipModel(allClipToastCount: 0, clips: []) {
-        didSet {
-            dataChangeAction?(!clipList.clips.isEmpty)
-        }
-    }
-}
-
-// MARK: - Extensions
-
-extension ClipViewModel {
-    func setupDataChangeAction(changeAction: @escaping DataChangeAction,
-                               forUnAuthorizedAction: @escaping NormalChangeAction,
-                               editAction: @escaping NormalChangeAction,
-                               moveAction: @escaping DataChangeAction) {
-        dataChangeAction = changeAction
-        unAuthorizedAction = forUnAuthorizedAction
-        textFieldEditAction = editAction
-        moveBottomAction = moveAction
-    }
-    
-    func getAllCategoryAPI() {
-        NetworkService.shared.clipService.getAllCategory { [weak self] result in
-            switch result {
-            case .success(let response):
-                let allClipToastCount = response?.data.toastNumberInEntire
-                let clips = response?.data.categories.map {
-                    AllClipModel(id: $0.categoryId,
-                                title: $0.categoryTitle,
-                                toastCount: $0.toastNum)
-                }
-                self?.clipList = ClipModel(allClipToastCount: allClipToastCount ?? 0,
-                                           clips: clips ?? [])
-            case .unAuthorized, .networkFail, .notFound:
-                self?.unAuthorizedAction?()
-            default: return
+        input.viewDidLoad
+            .flatMap { [weak self] _ -> AnyPublisher<ClipModel, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.getAllCategoryAPI()
+                    .catch { error -> AnyPublisher<ClipModel, Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }.eraseToAnyPublisher()
             }
-        }
-    }
-    
-    func postAddCategoryAPI(requestBody: String) {
-        NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
-            switch result {
-            case .success:
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.textFieldEditAction?()
-                }
-                self.getAllCategoryAPI()
-            case .unAuthorized, .networkFail, .notFound:
-                self.unAuthorizedAction?()
-            default: return
-            }
-        }
-    }
-    
-    func getCheckCategoryAPI(categoryTitle: String) {
-        NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
-            switch result {
-            case .success(let response):
-                if let data = response?.data.isDupicated {
-                    if categoryTitle.count != 16 {
-                        self.moveBottomAction?(data)
+            .sink { [weak self] clipList in
+                self?.clipList = clipList
+            }.store(in: cancelBag)
+                
+        input.clipNameChanged
+            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.getCheckCategoryAPI(categoryTitle: clipTitle)
+                    .catch { error -> AnyPublisher<Bool, Never> in
+                        return Empty().eraseToAnyPublisher()
                     }
-                }
-            case .unAuthorized, .networkFail, .notFound:
-                self.unAuthorizedAction?()
-            default: return
+                    .eraseToAnyPublisher()
             }
-        }
+            .sink { isDuplicate in
+                output.duplicateClipName.send(isDuplicate)
+            }.store(in: cancelBag)
+        
+        input.addClipButtonTapped
+            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.postAddCategoryAPI(requestBody: clipTitle)
+                    .catch { error -> AnyPublisher<Bool, Never> in
+                        return Empty().eraseToAnyPublisher()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .sink { isSuccess in
+                output.addClipResult.send(isSuccess)
+                if isSuccess { output.needToReload.send() }
+            }.store(in: cancelBag)
+        
+        return output
     }
 }
+
+// MARK: - Network
+
+private extension ClipViewModel {
+    func getAllCategoryAPI() -> AnyPublisher<ClipModel, Error> {
+        return Future<ClipModel, Error> { promise in
+            NetworkService.shared.clipService.getAllCategory { result in
+                switch result {
+                case .success(let response):
+                    let allClipToastCount = response?.data.toastNumberInEntire
+                    let clips = response?.data.categories.map {
+                        AllClipModel(id: $0.categoryId,
+                                     title: $0.categoryTitle,
+                                     toastCount: $0.toastNum)
+                    }
+                    promise(.success(ClipModel(allClipToastCount: allClipToastCount ?? 0, clips: clips ?? [])))
+                case .unAuthorized, .networkFail, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func getCheckCategoryAPI(categoryTitle: String) -> AnyPublisher<Bool, Error> {
+        return Future<Bool, Error> { promise in
+            NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
+                switch result {
+                case .success(let response):
+                    if let data = response?.data.isDupicated, categoryTitle.count < 16 {
+                        promise(.success(data))
+                    }
+                case .unAuthorized, .networkFail, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func postAddCategoryAPI(requestBody: String) -> AnyPublisher<Bool, Error> {
+        return Future<Bool, Error> { promise in
+            NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
+                switch result {
+                case .success:
+                    promise(.success(true))
+                case .unAuthorized, .networkFail, .notFound:
+                    promise(.failure(NetworkResult<Error>.unAuthorized))
+                default:
+                    return
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+}
+
+
+
+
+//
+//import Foundation
+//
+//final class ClipViewModel: NSObject {
+//    
+//    // MARK: - Properties
+//    
+//    typealias DataChangeAction = (Bool) -> Void
+//    private var dataChangeAction: DataChangeAction?
+//    private var moveBottomAction: DataChangeAction?
+//    
+//    typealias NormalChangeAction = () -> Void
+//    private var unAuthorizedAction: NormalChangeAction?
+//    private var textFieldEditAction: NormalChangeAction?
+//        
+//    // MARK: - Data
+//    
+//    private(set) var clipList: ClipModel = ClipModel(allClipToastCount: 0, clips: []) {
+//        didSet {
+//            dataChangeAction?(!clipList.clips.isEmpty)
+//        }
+//    }
+//}
+//
+//// MARK: - Extensions
+//
+//extension ClipViewModel {
+//    func setupDataChangeAction(changeAction: @escaping DataChangeAction,
+//                               forUnAuthorizedAction: @escaping NormalChangeAction,
+//                               editAction: @escaping NormalChangeAction,
+//                               moveAction: @escaping DataChangeAction) {
+//        dataChangeAction = changeAction
+//        unAuthorizedAction = forUnAuthorizedAction
+//        textFieldEditAction = editAction
+//        moveBottomAction = moveAction
+//    }
+//    
+//    func getAllCategoryAPI() {
+//        NetworkService.shared.clipService.getAllCategory { [weak self] result in
+//            switch result {
+//            case .success(let response):
+//                let allClipToastCount = response?.data.toastNumberInEntire
+//                let clips = response?.data.categories.map {
+//                    AllClipModel(id: $0.categoryId,
+//                                title: $0.categoryTitle,
+//                                toastCount: $0.toastNum)
+//                }
+//                self?.clipList = ClipModel(allClipToastCount: allClipToastCount ?? 0,
+//                                           clips: clips ?? [])
+//            case .unAuthorized, .networkFail, .notFound:
+//                self?.unAuthorizedAction?()
+//            default: return
+//            }
+//        }
+//    }
+//    
+//    func postAddCategoryAPI(requestBody: String) {
+//        NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
+//            switch result {
+//            case .success:
+//                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+//                    self.textFieldEditAction?()
+//                }
+//                self.getAllCategoryAPI()
+//            case .unAuthorized, .networkFail, .notFound:
+//                self.unAuthorizedAction?()
+//            default: return
+//            }
+//        }
+//    }
+//    
+//    func getCheckCategoryAPI(categoryTitle: String) {
+//        NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
+//            switch result {
+//            case .success(let response):
+//                if let data = response?.data.isDupicated {
+//                    if categoryTitle.count != 16 {
+//                        self.moveBottomAction?(data)
+//                    }
+//                }
+//            case .unAuthorized, .networkFail, .notFound:
+//                self.unAuthorizedAction?()
+//            default: return
+//            }
+//        }
+//    }
+//}

--- a/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
+++ b/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
@@ -44,6 +44,8 @@ final class ClipViewModel: ViewModelType {
             }.store(in: cancelBag)
                 
         input.clipNameChanged
+            .debounce(for: 0.2, scheduler: RunLoop.main)
+            .removeDuplicates()
             .networkFlatMap(self) { context, clipTitle in
                 context.getCheckCategoryAPI(categoryTitle: clipTitle)
             }

--- a/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
+++ b/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
@@ -35,12 +35,8 @@ final class ClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestClipList
-            .flatMap { [weak self] _ -> AnyPublisher<ClipModel, Never> in
-                guard let self else { return Empty().eraseToAnyPublisher() }
-                return self.getAllCategoryAPI()
-                    .catch { _ -> AnyPublisher<ClipModel, Never> in
-                        return Empty().eraseToAnyPublisher()
-                    }.eraseToAnyPublisher()
+            .networkFlatMap(self) { context, _ in
+                context.getAllCategoryAPI()
             }
             .sink { [weak self] clipList in
                 self?.clipList = clipList
@@ -48,26 +44,16 @@ final class ClipViewModel: ViewModelType {
             }.store(in: cancelBag)
                 
         input.clipNameChanged
-            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
-                guard let self else { return Empty().eraseToAnyPublisher() }
-                return self.getCheckCategoryAPI(categoryTitle: clipTitle)
-                    .catch { _ -> AnyPublisher<Bool, Never> in
-                        return Empty().eraseToAnyPublisher()
-                    }
-                    .eraseToAnyPublisher()
+            .networkFlatMap(self) { context, clipTitle in
+                context.getCheckCategoryAPI(categoryTitle: clipTitle)
             }
             .sink { isDuplicate in
                 output.duplicateClipName.send(isDuplicate)
             }.store(in: cancelBag)
         
         input.addClipButtonTapped
-            .flatMap { [weak self] clipTitle -> AnyPublisher<Bool, Never> in
-                guard let self else { return Empty().eraseToAnyPublisher() }
-                return self.postAddCategoryAPI(requestBody: clipTitle)
-                    .catch { _ -> AnyPublisher<Bool, Never> in
-                        return Empty().eraseToAnyPublisher()
-                    }
-                    .eraseToAnyPublisher()
+            .networkFlatMap(self) { context, clipTitle in
+                context.postAddCategoryAPI(requestBody: clipTitle)
             }
             .sink { isSuccess in
                 output.addClipResult.send(isSuccess)

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -288,7 +288,6 @@ private extension HomeViewController {
     }
     
     func setupToolTip() {
-        guard let secondToolTip else { return }
         if UserDefaults.standard.value(forKey: TipUserDefaults.isShowHomeViewToolTip) == nil {
             UserDefaults.standard.set(true, forKey: TipUserDefaults.isShowHomeViewToolTip)
             

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 김다예 on 12/30/23.
 //
+
 import UIKit
 
 import SnapKit
@@ -16,11 +17,6 @@ final class HomeViewController: UIViewController {
     private let viewModel = HomeViewModel()
     private let clipViewModel = DetailClipViewModel()
     private let homeView = HomeView()
-    
-    private let addClipBottomSheetView = AddClipBottomSheetView()
-    private lazy var addClipBottom = ToasterBottomSheetViewController(bottomType: .white,
-                                                                      bottomTitle: "클립 추가",
-                                                                      insertView: addClipBottomSheetView)
     
     private var firstToolTip: ToasterTipView?
     private lazy var secondToolTip: ToasterTipView? = {
@@ -270,7 +266,6 @@ private extension HomeViewController {
                         forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
                         withReuseIdentifier: HomeFooterCollectionView.className)
         }
-        addClipBottomSheetView.addClipBottomSheetViewDelegate = self
     }
     
     func setupDelegate() {
@@ -282,8 +277,6 @@ private extension HomeViewController {
     func setupViewModel() {
         viewModel.setupDataChangeAction(changeAction: reloadCollectionView,
                                         forUnAuthorizedAction: unAuthorizedAction,
-                                        editAction: addClipAction,
-                                        moveAction: moveBottomAction,
                                         popupAction: showPopupAction)
     }
     
@@ -308,28 +301,6 @@ private extension HomeViewController {
     
     func unAuthorizedAction() {
         changeViewController(viewController: LoginViewController())
-    }
-    
-    func moveBottomAction(isDuplicated: Bool) {
-        if isDuplicated {
-            addHeightBottom()
-            addClipBottomSheetView.changeTextField(addButton: false,
-                                                   border: true,
-                                                   error: true,
-                                                   clearButton: true)
-            addClipBottomSheetView.setupMessage(message: "이미 같은 이름의 클립이 있어요")
-        } else {
-            minusHeightBottom()
-        }
-    }
-    
-    func addClipAction() {
-        dismiss(animated: true) {
-            self.addClipBottomSheetView.resetTextField()
-            self.showToastMessage(width: 157,
-                                  status: .check,
-                                  message: StringLiterals.ToastMessage.completeAddClip)
-        }
     }
         
     func showPopupAction(isShow: Bool) {
@@ -384,26 +355,6 @@ private extension HomeViewController {
         let detailClipViewController = DetailClipViewController()
         detailClipViewController.setupCategory(id: 0, name: "전체 클립")
         navigationController?.pushViewController(detailClipViewController, animated: true)
-    }
-}
-
-// MARK: - AddClipBottomSheetViewDelegate
-
-extension HomeViewController: AddClipBottomSheetViewDelegate {
-    func callCheckAPI(text: String) {
-        viewModel.getCheckCategoryAPI(categoryTitle: text)
-    }
-    
-    func addHeightBottom() {
-        addClipBottom.setupSheetHeightChanges(bottomHeight: 219)
-    }
-    
-    func minusHeightBottom() {
-        addClipBottom.setupSheetHeightChanges(bottomHeight: 198)
-    }
-    
-    func dismissButtonTapped(title: String) {
-        viewModel.postAddCategoryAPI(requestBody: title)
     }
 }
 

--- a/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
+++ b/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
@@ -14,12 +14,10 @@ final class HomeViewModel {
     typealias DataChangeAction = (Bool) -> Void
     private var dataChangeAction: DataChangeAction?
     private var dataEmptyAction: DataChangeAction?
-    private var moveBottomAction: DataChangeAction?
     private var showPopupAction: DataChangeAction?
     
     typealias NormalChangeAction = () -> Void
     private var unAuthorizedAction: NormalChangeAction?
-    private var textFieldEditAction: NormalChangeAction?
     
     // MARK: - Data
     
@@ -82,13 +80,9 @@ extension HomeViewModel {
     
     func setupDataChangeAction(changeAction: @escaping DataChangeAction,
                                forUnAuthorizedAction: @escaping NormalChangeAction,
-                               editAction: @escaping NormalChangeAction,
-                               moveAction: @escaping DataChangeAction,
                                popupAction: @escaping DataChangeAction) {
         dataChangeAction = changeAction
         unAuthorizedAction = forUnAuthorizedAction
-        textFieldEditAction = editAction
-        moveBottomAction = moveAction
         showPopupAction = popupAction
     }
     
@@ -161,37 +155,6 @@ extension HomeViewModel {
                 self.unAuthorizedAction?()
             default:
                 return
-            }
-        }
-    }
-    
-    func getCheckCategoryAPI(categoryTitle: String) {
-        NetworkService.shared.clipService.getCheckCategory(categoryTitle: categoryTitle) { result in
-            switch result {
-            case .success(let response):
-                if let data = response?.data.isDupicated {
-                    if categoryTitle.count != 16 {
-                        self.moveBottomAction?(data)
-                    }
-                }
-            case .unAuthorized, .networkFail, .notFound:
-                self.unAuthorizedAction?()
-            default: return
-            }
-        }
-    }
-    
-    func postAddCategoryAPI(requestBody: String) {
-        NetworkService.shared.clipService.postAddCategory(requestBody: PostAddCategoryRequestDTO(categoryTitle: requestBody)) { result in
-            switch result {
-            case .success:
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    self.textFieldEditAction?()
-                }
-                self.fetchMainPageData()
-            case .networkFail, .unAuthorized, .notFound:
-                self.unAuthorizedAction?()
-            default: return
             }
         }
     }

--- a/TOASTER-iOS/Present/LinkWeb/ViewModel/LinkWebViewModel.swift
+++ b/TOASTER-iOS/Present/LinkWeb/ViewModel/LinkWebViewModel.swift
@@ -31,23 +31,14 @@ final class LinkWebViewModel: ViewModelType {
         let output = Output()
         
         input.readLinkButtonTapped
-            .flatMap { [weak self] model in
-                self?.performLinkReadRequest(model, output) ?? Driver.empty()
+            .networkFlatMap(self) { context, model in
+                context.patchOpenLinkAPI(requestBody: model)
             }
             .sink { isRead in
                 output.isRead.send(!isRead)
             }.store(in: cancelBag)
         
         return output
-    }
-    
-    func performLinkReadRequest(_ model: LinkReadEditModel, _ output: Output) -> Driver<Bool> {
-        return patchOpenLinkAPI(requestBody: model)
-            .handleEvents(receiveCompletion: { completion in
-                if case .failure = completion {
-                    output.navigateToLogin.send()
-                }
-            }).asDriver()
     }
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #235 

## 🛠️ 작업내용
### 1. ClipViewModel Combine 사용 리팩토링
- input : 클립 리스트 요청, 클립 이름 텍스트 필드 입력, 클립 추가 버튼 클릭
- output : 리로드, 클립 이름 중복값 결과, 클립 추가 결과

### 2. AddClipBottomSheetView 코드 수정
- 버튼 클릭 액션 이벤트 -> addTarget과 delegate로 전달되던 코드를 `addClipButton.publisher(for: .touchUpInside)`로 전달하도록 변경
- 중복값 체크시 사용되던 타이머 코드 삭제 -> 사유 : 텍스트 필드의 입력 값을 Publisher로 체크하게 되면서, 타이머 코드가 불필요하게 됨

### 3. SelectClipViewModel Combine 사용 리팩토링
> 해당 화면은 링크 저장 시 -> 클립 선택하는 부분에 해당하는 화면입니다!   

위에서 AddClipBottomSheetView 코드를 수정하게 되며, 해당 코드에 대한 부분도 수정이 필요해 리팩토링 진행하게 되었습니다.
- input : 클립 리스트 요청, 클립 이름 텍스트 필드 입력, 클립 추가 버튼 클릭, 링크 저장 버튼 클릭
- output : 리로드, 클립 이름 중복값 결과, 클립 추가 결과, 링크 저장 결과

### 4. HomeVC에서 더 이상 사용되지 않는 addClipBottomSheet 관련 코드 정리
v 1.2.0 업데이트 전에는 홈 화면에서 클립 추가가 바로 되는 상황이 있어 필요했지만, 현재 화면에서는 링크 접근 / 링크 추가로의 화면 전환 코드만 사용되어서 확인 후 삭제했습니다. 

### 5. networkFlatMap Custom Operator 추가 - 기존 코드 부분 수정
> 해당 코드에 대한 설명은 아래 부분을 참고해주세요!

기존 Publisher에서 네트워크 호출과 이에 대한 예외 처리로 flatMap을 사용하는 부분을 줄일 수 있도록 - 재사용 Operator를 Extension에 추가, 기존 코드 대체 가능한 부분 변경했습니다!

<br>

## 🖥️ 주요 코드 설명
<!-- 다음에 진행할 작업에 대해 작성해주세요 -->
`networkFlatMap`은 네트워크 함수 호출 시
`flatMap` 연산을 수행하면서, 메모리 누수 방지(약한 참조)와 에러 처리를 위한 반복 코드 사용을 줄이기 위한 커스텀 Operator입니다.
https://github.com/Link-MIND/TOASTER-iOS/blob/6ecc7633cb5610de2cab28c8ac6186b4d0ba29fb/TOASTER-iOS/Global/Extensions/Combine%2B/Publisher%2BOperator.swift#L11-L33

[기존 코드]
```Swift
Publisher
    .flatMap { [weak self] value -> AnyPublisher<Bool, Never> in
        guard let self else { return Empty().eraseToAnyPublisher() }  // self 약한 참조
        
        return self.patchChagneCategory(value: value)   // 네트워크 함수 호출
            // 예외 처리
            .catch { error -> AnyPublisher<Bool, Never> in   
                print("Error: \(error)")
                return Empty().eraseToAnyPublisher()
            }
            .eraseToAnyPublisher()
```

[networkFlatMap 연산자 사용]
```Swift
Publisher
    .networkFlatMap(self) { context, value in
       context.patchChagneCategory(value: value)
    }
```


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
