### PR TITLE
[Fix] #247 - 리프레시 토큰 만료시 Root 화면 전환 로직 버그 해결

### DIFF
--- a/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
@@ -56,7 +56,8 @@ private extension AddLinkCoordinator {
             })
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
@@ -55,6 +55,9 @@ private extension AddLinkCoordinator {
                 self?.onFinish?()
             })
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true)
     }
 }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
@@ -63,6 +63,9 @@ private extension ClipCoordinator {
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
 }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
@@ -40,7 +40,8 @@ private extension ClipCoordinator {
             self?.showDetailClipVC(id: clipId, name: clipName)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.setRoot(vc, animated: false)
     }
@@ -49,7 +50,8 @@ private extension ClipCoordinator {
         let vc = viewControllerFactory.makeEditClipVC()
         vc.setupDataBind(clipModel: clipList)
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: false, hideBottomBarWhenPushed: true)
     }
@@ -61,7 +63,8 @@ private extension ClipCoordinator {
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -73,7 +76,8 @@ private extension ClipCoordinator {
             self?.router.pop(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
@@ -39,12 +39,18 @@ private extension ClipCoordinator {
         vc.onClipItemSelected = { [weak self] clipId, clipName in
             self?.showDetailClipVC(id: clipId, name: clipName)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.setRoot(vc, animated: false)
     }
     
     func showEditClipVC(clipList: ClipModel) {
         let vc = viewControllerFactory.makeEditClipVC()
         vc.setupDataBind(clipModel: clipList)
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: false, hideBottomBarWhenPushed: true)
     }
     
@@ -53,6 +59,9 @@ private extension ClipCoordinator {
         vc.setupCategory(id: id, name: name)
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
@@ -48,6 +48,9 @@ private extension HomeCoordinator {
         vc.onAddLinkSelected = { [weak self] in
             self?.startAddLinkCoordinator()
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.setRoot(vc, animated: false)
     }
     
@@ -80,6 +83,9 @@ private extension HomeCoordinator {
         vc.setupCategory(id: id, name: name)
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
@@ -57,6 +57,9 @@ private extension HomeCoordinator {
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -65,6 +68,9 @@ private extension HomeCoordinator {
         vc.onChangeRoot = { [weak self] in
             self?.router.dismiss()
             self?.onFinish?()
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
@@ -49,7 +49,8 @@ private extension HomeCoordinator {
             self?.startAddLinkCoordinator()
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.setRoot(vc, animated: false)
     }
@@ -61,7 +62,8 @@ private extension HomeCoordinator {
             self?.router.pop(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -69,11 +71,12 @@ private extension HomeCoordinator {
     func showSettingVC() {
         let vc = viewControllerFactory.makeSettingVC()
         vc.onChangeRoot = { [weak self] in
-            self?.router.dismiss()
+            self?.router.dismiss()  // 로그아웃 완료 Alert dismiss
             self?.onFinish?()
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -85,7 +88,9 @@ private extension HomeCoordinator {
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
@@ -39,6 +39,9 @@ private extension SearchCoordinator {
         vc.onClipItemSelected = { [weak self] id, name in
             self?.showDetailClipVC(id: id, name: name)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.setRoot(vc, animated: false)
     }
     
@@ -48,6 +51,9 @@ private extension SearchCoordinator {
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -56,6 +62,9 @@ private extension SearchCoordinator {
         vc.setupDataBind(linkURL: linkURL, isRead: isRead, id: id)
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         vc.onRootDeleteToken = { [weak self] in
             self?.router.setRootWithDeleteToken()

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
@@ -57,6 +57,9 @@ private extension SearchCoordinator {
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
 }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
@@ -40,7 +40,8 @@ private extension SearchCoordinator {
             self?.showDetailClipVC(id: id, name: name)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.setRoot(vc, animated: false)
     }
@@ -52,7 +53,8 @@ private extension SearchCoordinator {
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -64,10 +66,8 @@ private extension SearchCoordinator {
             self?.router.pop(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
@@ -122,6 +122,7 @@ private extension TabBarCoordinator {
             self?.tabBarController?.selectTab(0)
             self?.router.popToRoot(animated: false)
         }
+        
         router.push(vc, animated: false)
     }
     

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
@@ -81,6 +81,7 @@ private extension TabBarCoordinator {
         )
         coordinator.onFinish = { [weak self, weak coordinator] in
             self?.removeDependency(coordinator)
+            self?.onFinish?()
         }
         self.addDependency(coordinator)
         coordinator.start()
@@ -94,6 +95,7 @@ private extension TabBarCoordinator {
         )
         coordinator.onFinish = { [weak self, weak coordinator] in
             self?.removeDependency(coordinator)
+            self?.onFinish?()
         }
         self.addDependency(coordinator)
         coordinator.start()
@@ -122,7 +124,6 @@ private extension TabBarCoordinator {
             self?.tabBarController?.selectTab(0)
             self?.router.popToRoot(animated: false)
         }
-        
         router.push(vc, animated: false)
     }
     

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
@@ -45,6 +45,9 @@ private extension TimerCoordinator {
         vc.onSettingSelected = { [weak self] in
             self?.showSettingVC()
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.setRoot(vc, animated: false)
     }
     
@@ -65,6 +68,9 @@ private extension TimerCoordinator {
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -73,6 +79,9 @@ private extension TimerCoordinator {
         vc.configureView(forModel: model)
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -92,6 +101,9 @@ private extension TimerCoordinator {
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -100,6 +112,9 @@ private extension TimerCoordinator {
         vc.onChangeRoot = { [weak self] in
             self?.router.dismiss()
             self?.onFinish?()
+        }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
@@ -92,6 +92,9 @@ private extension TimerCoordinator {
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            self?.router.setRootWithDeleteToken()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
@@ -46,7 +46,8 @@ private extension TimerCoordinator {
             self?.showSettingVC()
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.setRoot(vc, animated: false)
     }
@@ -59,6 +60,10 @@ private extension TimerCoordinator {
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
         }
+        vc.onRootDeleteToken = { [weak self] in
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
+        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -69,7 +74,8 @@ private extension TimerCoordinator {
             self?.router.popToRoot(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -81,7 +87,8 @@ private extension TimerCoordinator {
             self?.router.popToRoot(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -93,7 +100,8 @@ private extension TimerCoordinator {
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -105,7 +113,8 @@ private extension TimerCoordinator {
             self?.router.pop(animated: true)
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -117,7 +126,8 @@ private extension TimerCoordinator {
             self?.onFinish?()
         }
         vc.onRootDeleteToken = { [weak self] in
-            self?.router.setRootWithDeleteToken()
+            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Router.swift
+++ b/TOASTER-iOS/Application/Coordinator/Router.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol RouterProtocol: AnyObject {
     func setRoot(_ viewController: UIViewController, animated: Bool)
     func setRoot(_ viewController: UIViewController, animated: Bool, hideBottomBarWhenPushed: Bool)
+    func setRootWithDeleteToken()
     
     func popToRoot(animated: Bool)
     
@@ -42,6 +43,11 @@ final class Router: RouterProtocol {
     ) {
         viewController.hidesBottomBarWhenPushed = hideBottomBarWhenPushed
         rootViewController?.setViewControllers([viewController], animated: animated)
+    }
+    
+    func setRootWithDeleteToken() {
+        _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
+        rootViewController?.setViewControllers([LoginViewController()], animated: true)
     }
     
     func popToRoot(animated: Bool) {

--- a/TOASTER-iOS/Application/Coordinator/Router.swift
+++ b/TOASTER-iOS/Application/Coordinator/Router.swift
@@ -10,7 +10,6 @@ import UIKit
 protocol RouterProtocol: AnyObject {
     func setRoot(_ viewController: UIViewController, animated: Bool)
     func setRoot(_ viewController: UIViewController, animated: Bool, hideBottomBarWhenPushed: Bool)
-    func setRootWithDeleteToken()
     
     func popToRoot(animated: Bool)
     
@@ -43,11 +42,6 @@ final class Router: RouterProtocol {
     ) {
         viewController.hidesBottomBarWhenPushed = hideBottomBarWhenPushed
         rootViewController?.setViewControllers([viewController], animated: animated)
-    }
-    
-    func setRootWithDeleteToken() {
-        _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-        rootViewController?.setViewControllers([LoginViewController()], animated: true)
     }
     
     func popToRoot(animated: Bool) {

--- a/TOASTER-iOS/Global/Extensions/Combine+/Publisher+Operator.swift
+++ b/TOASTER-iOS/Global/Extensions/Combine+/Publisher+Operator.swift
@@ -17,6 +17,7 @@ public extension Publisher {
     func networkFlatMap<SelfPublisher: AnyObject, NewPublisher: Publisher>(
         _ weakSelf: SelfPublisher?,
         _ firstTransform: @escaping (SelfPublisher, Output) -> NewPublisher,
+        onError: ((Error) -> Void)? = nil,
         _ secondTransform: @escaping (Error) -> AnyPublisher<NewPublisher.Output, Never> = { _ in
             Empty().eraseToAnyPublisher()
         }
@@ -25,7 +26,10 @@ public extension Publisher {
         self.flatMap { [weak weakSelf] output -> AnyPublisher<NewPublisher.Output, Never> in
             guard let weakSelf else { return Empty().eraseToAnyPublisher() }
             return firstTransform(weakSelf, output)
-                .catch { secondTransform($0) }
+                .catch {
+                    onError?($0)
+                    return secondTransform($0)
+                }
                 .eraseToAnyPublisher()
         }
         .eraseToAnyPublisher()

--- a/TOASTER-iOS/Global/Extensions/UIKit+/UIViewController+.swift
+++ b/TOASTER-iOS/Global/Extensions/UIKit+/UIViewController+.swift
@@ -100,23 +100,4 @@ extension UIViewController {
             toastView.removeFromSuperview()
         })
     }
-    
-    /// rootVIewController 를 변경해주는 메서드
-    func changeViewController(viewController: UIViewController) {
-        switch viewController {
-        case is LoginViewController:
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            
-            // alret 관련 동작을 넣으면 좋을거 같습니다.
-        default:
-            print("🍞⛔️해당하는 ViewController 가 없습니다!⛔️🍞")
-        }
-        
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-            if let window = windowScene.windows.first {
-                window.rootViewController = ToasterNavigationController(rootViewController: viewController)
-                print("🍞⛔️\(String(describing: type(of: viewController)))⛔️🍞")
-            }
-        }
-    }
 }

--- a/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/LinkEmbed/View/AddLinkViewController.swift
@@ -31,7 +31,6 @@ final class AddLinkViewController: UIViewController {
     
     private var isNavigationBarHidden: Bool
     
-    // private weak var delegate: AddLinkViewControllerPopDelegate?
     private weak var urldelegate: SelectClipViewControllerDelegate?
     
     private var addLinkView = AddLinkView()

--- a/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
@@ -16,6 +16,7 @@ final class SelectClipViewController: UIViewController {
     // MARK: - View Controllable
 
     var onPopToRoot: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -148,6 +149,11 @@ private extension SelectClipViewController {
                 self?.navigationController?.showToastMessage(width: width, status: status, message: message)
                 self?.onPopToRoot?()
                 if isSuccess { self?.delegate?.saveLinkButtonTapped() }
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/ViewModel/SelectClipViewModel.swift
@@ -29,6 +29,7 @@ final class SelectClipViewModel: ViewModelType {
         let duplicateClipName = PassthroughSubject<Bool, Never>()
         let addClipResult = PassthroughSubject<Bool, Never>()
         let saveLinkResult = PassthroughSubject<Bool, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -37,9 +38,11 @@ final class SelectClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestClipList
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchClipData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] clipDataList in
                 self?.selectedClip = clipDataList
                 output.needToReload.send()
@@ -48,17 +51,21 @@ final class SelectClipViewModel: ViewModelType {
         input.clipNameChanged
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .removeDuplicates()
-            .networkFlatMap(self) { context, clipTitle in
+            .networkFlatMap(self, { context, clipTitle in
                 context.getCheckCategoryAPI(categoryTitle: clipTitle)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isDuplicate in
                 output.duplicateClipName.send(isDuplicate)
             }.store(in: cancelBag)
         
         input.addClipButtonTapped
-            .networkFlatMap(self) { context, clipTitle in
+            .networkFlatMap(self, { context, clipTitle in
                 context.postAddCategoryAPI(requestBody: clipTitle)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isSuccess in
                 output.addClipResult.send(isSuccess)
                 if isSuccess {
@@ -67,9 +74,11 @@ final class SelectClipViewModel: ViewModelType {
             }.store(in: cancelBag)
         
         input.completeButtonTapped
-            .networkFlatMap(self) { context, body in
+            .networkFlatMap(self, { context, body in
                 context.postSaveLink(url: body.0, category: body.1)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { result in
                 output.saveLinkResult.send(result)
             }.store(in: cancelBag)

--- a/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
+++ b/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
@@ -17,6 +17,7 @@ final class ClipViewController: UIViewController {
     
     var onEditClipSelected: ((ClipModel) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - UI Properties
     
@@ -109,6 +110,11 @@ private extension ClipViewController {
                 } else {
                     self?.minusHeightBottom()
                 }
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
+++ b/TOASTER-iOS/Present/Clip/ViewModel/ClipViewModel.swift
@@ -27,6 +27,7 @@ final class ClipViewModel: ViewModelType {
         let needToReload = PassthroughSubject<Void, Never>()
         let addClipResult = PassthroughSubject<Bool, Never>()
         let duplicateClipName = PassthroughSubject<Bool, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -35,9 +36,11 @@ final class ClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestClipList
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.getAllCategoryAPI()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] clipList in
                 self?.clipList = clipList
                 output.needToReload.send()
@@ -46,17 +49,21 @@ final class ClipViewModel: ViewModelType {
         input.clipNameChanged
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .removeDuplicates()
-            .networkFlatMap(self) { context, clipTitle in
+            .networkFlatMap(self, { context, clipTitle in
                 context.getCheckCategoryAPI(categoryTitle: clipTitle)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isDuplicate in
                 output.duplicateClipName.send(isDuplicate)
             }.store(in: cancelBag)
         
         input.addClipButtonTapped
-            .networkFlatMap(self) { context, clipTitle in
+            .networkFlatMap(self, { context, clipTitle in
                 context.postAddCategoryAPI(requestBody: clipTitle)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isSuccess in
                 output.addClipResult.send(isSuccess)
                 if isSuccess {

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -16,6 +16,7 @@ final class DetailClipViewController: UIViewController {
     // MARK: - View Controllable
     
     var onLinkSelected: ((String, Bool, Int) -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Streams
     
@@ -224,6 +225,11 @@ private extension DetailClipViewController {
                         message: StringLiterals.ToastMessage.completeDeleteLink
                     )
                 }
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
+++ b/TOASTER-iOS/Present/DetailClip/ViewModel/DetailClipViewModel.swift
@@ -44,6 +44,7 @@ final class DetailClipViewModel: ViewModelType {
         let isCompleteButtonEnable = PassthroughSubject<Bool, Never>()
         let changeCategoryResult = PassthroughSubject<Bool, Never>()
         let deleteToastComplete = PassthroughSubject<Void, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -52,20 +53,22 @@ final class DetailClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestToast
-            .networkFlatMap(self) { context, isAll in
+            .networkFlatMap(self, { context, isAll in
                 if isAll {
                     context.getDetailAllCategoryAPI(filter: .all)
                 } else {
                     context.getDetailCategoryAPI(categoryID: self.currentCategoryId, filter: .all)
                 }
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] toasts in
                 self?.toastList = toasts
                 output.loadToToastList.send(!toasts.toastList.isEmpty)
             }.store(in: cancelBag)
         
         input.changeSegmentIndex
-            .networkFlatMap(self) { context, index in
+            .networkFlatMap(self, { context, index in
                 if self.currentCategoryId == 0 {
                     switch index {
                     case 0:
@@ -85,23 +88,27 @@ final class DetailClipViewModel: ViewModelType {
                         context.getDetailCategoryAPI(categoryID: self.currentCategoryId, filter: .unread)
                     }
                 }
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] toasts in
                 self?.toastList = toasts
                 output.loadToToastList.send(!toasts.toastList.isEmpty)
             }.store(in: cancelBag)
         
         input.editToastTitleButtonTap
-            .networkFlatMap(self) { context, toast in
+            .networkFlatMap(self, { context, toast in
                 context.patchEditLinkTitleAPI(toastId: toast.0, title: toast.1)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] isSuccess in
                 output.toastNameChanged.send(isSuccess)
                 output.loadToToastList.send(self?.currentCategoryId == 0)
             }.store(in: cancelBag)
         
         input.changeClipButtonTap
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.getAllCategoryAPI()
                     .map { [weak self] result -> [SelectClipModel]? in
                         guard let self = self else { return [] }
@@ -110,7 +117,9 @@ final class DetailClipViewModel: ViewModelType {
                         self.collectionViewHeight = self.calculateCollectionViewHeight(numberOfItems: sortedResult.count)
                         return sortedResult
                     }
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { model in
                 output.loadToClipData.send(model)
             }.store(in: cancelBag)
@@ -127,17 +136,21 @@ final class DetailClipViewModel: ViewModelType {
             .zip(input.selectedClip) { _, selectedClip in
                 return selectedClip
             }
-            .networkFlatMap(self) { context, selectClip in
+            .networkFlatMap(self, { context, selectClip in
                 context.patchChangeCategory(categoryId: selectClip)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { result in
                 output.changeCategoryResult.send(result)
             }.store(in: cancelBag)
         
         input.deleteToastButtonTap
-            .networkFlatMap(self) { context, toastId in
+            .networkFlatMap(self, { context, toastId in
                 context.deleteLinkAPI(toastId: toastId)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] _ in
                 output.loadToToastList.send(self?.currentCategoryId == 0)
                 output.deleteToastComplete.send()

--- a/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
+++ b/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
@@ -13,6 +13,10 @@ import Then
 
 final class EditClipViewController: UIViewController {
     
+    // MARK: - View Controllable
+    
+    var onRootDeleteToken: (() -> Void)?
+    
     // MARK: - Data Stream
         
     private let viewModel: EditClipViewModel
@@ -141,6 +145,11 @@ private extension EditClipViewController {
                     )
                     self?.editClipBottomSheetView.resetTextField()
                 }
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/EditClip/ViewModel/EditClipViewModel.swift
+++ b/TOASTER-iOS/Present/EditClip/ViewModel/EditClipViewModel.swift
@@ -32,6 +32,7 @@ final class EditClipViewModel: ViewModelType {
         let deleteClipResult = PassthroughSubject<Void, Never>()
         let duplicateClipName = PassthroughSubject<Bool, Never>()
         let changeClipNameResult = PassthroughSubject<Bool, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -40,18 +41,22 @@ final class EditClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestClipList
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.getAllCategoryAPI()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] clipList in
                 self?.clipList = clipList
                 output.needToReload.send()
             }.store(in: cancelBag)
         
         input.deleteClipButtonTapped
-            .networkFlatMap(self) { context, clipID in
+            .networkFlatMap(self, { context, clipID in
                 context.deleteCategoryAPI(deleteCategoryDto: clipID)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { _ in
                 output.deleteClipResult.send()
                 output.needToReload.send()
@@ -60,25 +65,31 @@ final class EditClipViewModel: ViewModelType {
         input.clipNameChanged
             .debounce(for: 0.2, scheduler: RunLoop.main)
             .removeDuplicates()
-            .networkFlatMap(self) { context, clipTitle in
+            .networkFlatMap(self, { context, clipTitle in
                 context.getCheckCategoryAPI(categoryTitle: clipTitle)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isDuplicated in
                 output.duplicateClipName.send(isDuplicated)
             }.store(in: cancelBag)
         
         input.changeClipNameButtonTapped
-            .networkFlatMap(self) { context, model in
+            .networkFlatMap(self, { context, model in
                 context.patchEditNameCategoryAPI(requestBody: model)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isSuccess in
                 output.changeClipNameResult.send(isSuccess)
             }.store(in: cancelBag)
         
         input.clipOrderedChanged
-            .networkFlatMap(self) { context, model in
+            .networkFlatMap(self, { context, model in
                 context.patchEditPriorityCategoryAPI(requestBody: model)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { _ in
                 output.needToReload.send()
             }.store(in: cancelBag)

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -20,6 +20,7 @@ final class HomeViewController: UIViewController {
     var onSettingSelected: (() -> Void)?
     var onArrowSelected: ((Int, String) -> Void)?
     var onAddLinkSelected: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Stream
     
@@ -258,6 +259,11 @@ private extension HomeViewController {
             .sink { [weak self] in
                 guard let self else { return }
                 homeView.collectionView.reloadData()
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
+++ b/TOASTER-iOS/Present/Home/ViewModel/HomeViewModel.swift
@@ -66,6 +66,7 @@ final class HomeViewModel: ViewModelType {
     
     struct Output {
         let needToReload = PassthroughSubject<Void, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -74,53 +75,65 @@ final class HomeViewModel: ViewModelType {
         let output = Output()
         
         input.requestMainInfo
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchMainPageData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] mainInfo in
                 self?.mainInfo = mainInfo
                 output.needToReload.send()
             }.store(in: cancelBag)
         
         input.requestRecentLinks
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchRecentLinkData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] recentLinks in
                 self?.recentLinks = recentLinks
                 output.needToReload.send()
             }.store(in: cancelBag)
         
         input.requestWeeklyLinks
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchWeeklyLinkData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] weeklyLinks in
                 self?.weeklyLinks = weeklyLinks
                 output.needToReload.send()
             }.store(in: cancelBag)
         
         input.requestRecommendSites
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchRecommendSiteData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] recommendSites in
                 self?.recommendSites = recommendSites
                 output.needToReload.send()
             }.store(in: cancelBag)
         
         input.requestPopupInfoList
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchPopupInfoAPI()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] popupInfoList in
                 self?.popupInfoList = popupInfoList
             }.store(in: cancelBag)
         
         input.changePopupDate
-            .networkFlatMap(self) { context, body in
+            .networkFlatMap(self, { context, body in
                 context.patchEditPopupHiddenAPI(popupId: body.0, hideDate: body.1)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] in
                 self?.popupInfoList?.removeAll()
             }.store(in: cancelBag)

--- a/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
+++ b/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
@@ -16,6 +16,7 @@ final class LinkWebViewController: UIViewController {
     // MARK: - View Controllable
     
     var onBack: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -123,7 +124,7 @@ private extension LinkWebViewController {
         
         output.navigateToLogin
             .sink { [weak self] _ in
-                self?.changeViewController(viewController: LoginViewController())
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/LinkWeb/ViewModel/LinkWebViewModel.swift
+++ b/TOASTER-iOS/Present/LinkWeb/ViewModel/LinkWebViewModel.swift
@@ -31,9 +31,11 @@ final class LinkWebViewModel: ViewModelType {
         let output = Output()
         
         input.readLinkButtonTapped
-            .networkFlatMap(self) { context, model in
+            .networkFlatMap(self, { context, model in
                 context.patchOpenLinkAPI(requestBody: model)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { isRead in
                 output.isRead.send(!isRead)
             }.store(in: cancelBag)

--- a/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
+++ b/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
@@ -26,6 +26,7 @@ final class RemindViewController: UIViewController {
     var onEditTimerSelected: ((Int) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
     var onSettingSelected: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -221,7 +222,7 @@ private extension RemindViewController {
     }
     
     func unAuthorizedAction() {
-        self.changeViewController(viewController: LoginViewController())
+        onRootDeleteToken?()
     }
     
     func deleteAction() {

--- a/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
@@ -77,6 +77,11 @@ private extension RemindSelectClipViewController {
                 guard let self else { return }
                 clipSelectCollectionView.reloadData()
             }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
+            }.store(in: cancelBag)
     }
     
     func setupStyle() {

--- a/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
@@ -16,6 +16,7 @@ final class RemindSelectClipViewController: UIViewController {
     
     var onEditTimerSelected: ((RemindClipModel?) -> Void)?
     var onPopToRoot: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
 
     // MARK: - Properties
     

--- a/TOASTER-iOS/Present/RemindAdd/ClipAdd/ViewModel/RemindSelectClipViewModel.swift
+++ b/TOASTER-iOS/Present/RemindAdd/ClipAdd/ViewModel/RemindSelectClipViewModel.swift
@@ -23,6 +23,7 @@ final class RemindSelectClipViewModel: ViewModelType {
     
     struct Output {
         let needToReload = PassthroughSubject<Void, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -31,9 +32,11 @@ final class RemindSelectClipViewModel: ViewModelType {
         let output = Output()
         
         input.requestClipList
-            .networkFlatMap(self) { context, _ in
+            .networkFlatMap(self, { context, _ in
                 context.fetchClipData()
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] clips in
                 self?.clips = clips
                 output.needToReload.send()

--- a/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
@@ -194,6 +194,11 @@ private extension RemindTimerAddViewController {
                 guard let self else { return }
                 showToastMessage(width: 297, status: .warning, message: error)
             }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
+            }.store(in: cancelBag)
     }
     
     func setupStyle() {
@@ -339,10 +344,6 @@ private extension RemindTimerAddViewController {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(14)
         }
-    }
-    
-    func unAuthorizedAction() {
-        onRootDeleteToken?()
     }
     
     func setupNavigationBar() {

--- a/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
@@ -19,6 +19,7 @@ final class RemindTimerAddViewController: UIViewController {
     // MARK: - View Controllable
 
     var onPopToRoot: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -284,7 +285,7 @@ private extension RemindTimerAddViewController {
     }
     
     func unAuthorizedAction() {
-        self.changeViewController(viewController: LoginViewController())
+        onRootDeleteToken?()
     }
     
     func patchSuccessAction() {

--- a/TOASTER-iOS/Present/RemindAdd/TimerAdd/ViewModel/RemindTimerAddViewModel.swift
+++ b/TOASTER-iOS/Present/RemindAdd/TimerAdd/ViewModel/RemindTimerAddViewModel.swift
@@ -28,6 +28,7 @@ final class RemindTimerAddViewModel: ViewModelType {
         let onSetTimerSuccess = PassthroughSubject<Void, Never>()
         let onEditTimerSuccess = PassthroughSubject<Void, Never>()
         let onError = PassthroughSubject<String, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -36,9 +37,11 @@ final class RemindTimerAddViewModel: ViewModelType {
         let output = Output()
         
         input.requestGetDetailTimer
-            .networkFlatMap(self) { context, timerID in
+            .networkFlatMap(self, { context, timerID in
                 context.getDetailTimerAPI(forID: timerID)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] data in
                 self?.remindAddData = data
                 output.onSetView.send()
@@ -61,9 +64,11 @@ final class RemindTimerAddViewModel: ViewModelType {
             }.store(in: cancelBag)
         
         input.completeEditButtonTapped
-            .networkFlatMap(self) { context, model in
+            .networkFlatMap(self, { context, model in
                 context.patchEditTimerAPI(forModel: model)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink {
                 output.onEditTimerSuccess.send()
             }.store(in: cancelBag)

--- a/TOASTER-iOS/Present/Search/View/SearchViewController.swift
+++ b/TOASTER-iOS/Present/Search/View/SearchViewController.swift
@@ -17,6 +17,7 @@ final class SearchViewController: UIViewController {
     
     var onLinkItemSelected: ((String, Bool, Int) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Stream
 
@@ -102,6 +103,11 @@ private extension SearchViewController {
                 guard let self else { return }
                 searchButton.isHidden = !isSearching
                 clearButton.isHidden = isSearching
+            }.store(in: cancelBag)
+        
+        output.navigateToLogin
+            .sink { [weak self] _ in
+                self?.onRootDeleteToken?()
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Search/ViewModel/SearchViewModel.swift
+++ b/TOASTER-iOS/Present/Search/ViewModel/SearchViewModel.swift
@@ -30,6 +30,7 @@ final class SearchViewModel: ViewModelType {
         let loadToSearchResults = PassthroughSubject<Bool, Never>()
         let startSearching = PassthroughSubject<Void, Never>()
         let isSearching = PassthroughSubject<Bool, Never>()
+        let navigateToLogin = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - Method
@@ -39,9 +40,11 @@ final class SearchViewModel: ViewModelType {
 
         input.searchButtonTapped
             .filter { !$0.isEmpty }
-            .networkFlatMap(self) { context, text in
+            .networkFlatMap(self, { context, text in
                 context.fetchSearchResult(forText: text)
-            }
+            }, onError: { _ in
+                output.navigateToLogin.send()
+            })
             .sink { [weak self] result in
                 self?.searchResults = result
                 output.loadToSearchResults.send(result.detailClipList.isEmpty && result.clipList.isEmpty)

--- a/TOASTER-iOS/Present/Setting/View/SettingViewController.swift
+++ b/TOASTER-iOS/Present/Setting/View/SettingViewController.swift
@@ -15,6 +15,7 @@ final class SettingViewController: UIViewController {
     // MARK: - View Controllable
 
     var onChangeRoot: (() -> Void)?
+    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -124,9 +125,8 @@ private extension SettingViewController {
                     self?.userName = responseData.nickname
                 }
             case .unAuthorized, .networkFail:
-                self?.changeViewController(viewController: LoginViewController())
-            default:
-                self?.changeViewController(viewController: LoginViewController())
+                self?.onRootDeleteToken?()
+            default: break
             }
         }
     }
@@ -176,7 +176,7 @@ private extension SettingViewController {
                 self.isToggle = response?.data?.isAllowed
                 self.setupWarningView()
             case .notFound, .networkFail:
-                self.changeViewController(viewController: LoginViewController())
+                self.onRootDeleteToken?()
             default: break
             }
         }
@@ -200,7 +200,7 @@ private extension SettingViewController {
                     }
                 }
             case .unAuthorized, .networkFail:
-                self?.changeViewController(viewController: LoginViewController())
+                self?.onRootDeleteToken?()
             default:
                 print("default Fail")
             }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #247  

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->

리프레시 토큰이 만료되면, 
Combine ViewModel로 리팩토링하면서 `promise(.failure(NetworkResult<Error>.unAuthorized))`
로그인으로의 화면 전환이 되지 않던 문제를 임시방편으로 해결했습니다~

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
