### PR TITLE
[Refactor] #252 - .unAuthorized 케이스 이벤트 브로드캐스팅 방식 채택 (NotificationCenter)

### DIFF
--- a/TOASTER-iOS.xcodeproj/project.pbxproj
+++ b/TOASTER-iOS.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		39EF95FF2B501BD600F301FC /* EditClipViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF95FE2B501BD600F301FC /* EditClipViewController.swift */; };
 		39EF96012B501E8A00F301FC /* EditClipNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF96002B501E8A00F301FC /* EditClipNoticeView.swift */; };
 		39EF96042B5020D600F301FC /* EditClipCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39EF96032B5020D600F301FC /* EditClipCollectionViewCell.swift */; };
+		3D20B9912DF056AB00D7775A /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D20B9902DF056AB00D7775A /* Notification.swift */; };
+		3D20B9922DF056AB00D7775A /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D20B9902DF056AB00D7775A /* Notification.swift */; };
 		3F1F26182BAA8E7D004F75CE /* SUIT-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 39BC5B0E2B410EF2004024E6 /* SUIT-Bold.otf */; };
 		3F1F261B2BAA9820004F75CE /* RemindSelectClipCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA032B4F2AF5008B06FA /* RemindSelectClipCollectionViewCell.swift */; };
 		3F1F261C2BAA9887004F75CE /* RemindSelectClipViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE6DA0A2B4F3063008B06FA /* RemindSelectClipViewModel.swift */; };
@@ -446,6 +448,7 @@
 		39EF95FE2B501BD600F301FC /* EditClipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditClipViewController.swift; sourceTree = "<group>"; };
 		39EF96002B501E8A00F301FC /* EditClipNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditClipNoticeView.swift; sourceTree = "<group>"; };
 		39EF96032B5020D600F301FC /* EditClipCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditClipCollectionViewCell.swift; sourceTree = "<group>"; };
+		3D20B9902DF056AB00D7775A /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		3F1F26252BAAC231004F75CE /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		3F2BFAC82B40370D00DA76B7 /* SocialLoginButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginButtonView.swift; sourceTree = "<group>"; };
 		3F2BFACA2B40373C00DA76B7 /* SocialLoginType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginType.swift; sourceTree = "<group>"; };
@@ -1135,6 +1138,7 @@
 			children = (
 				39BC5B182B411037004024E6 /* FontLiterals.swift */,
 				830517642B42D996009FFB60 /* StringLiterals.swift */,
+				3D20B9902DF056AB00D7775A /* Notification.swift */,
 			);
 			path = Consts;
 			sourceTree = "<group>";
@@ -2019,6 +2023,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D20B9922DF056AB00D7775A /* Notification.swift in Sources */,
 				39788C772CFF2A1300956A92 /* Publisher+Operator.swift in Sources */,
 				3F3ED28A2BA1A456004E79F0 /* AuthTargetType.swift in Sources */,
 				396DCDFD2CA19F4500FEF7C8 /* PatchPopupHiddenRequestDTO.swift in Sources */,
@@ -2262,6 +2267,7 @@
 				396D7ECD2C880F1F0034A14E /* LinkWebToolBarView.swift in Sources */,
 				6BE6DA732B50C33A008B06FA /* GetAllCategoryResponseDTO.swift in Sources */,
 				3F2FA1752B45C0AF00EDBF95 /* Config.swift in Sources */,
+				3D20B9912DF056AB00D7775A /* Notification.swift in Sources */,
 				83D80DCC2CC1059000DD5410 /* RecentLinkModel.swift in Sources */,
 				3F82C3212CADA19300492EEE /* Publisher+UIButton.swift in Sources */,
 				6B6AE6AC2B3FF6F7000E2366 /* UIColor+.swift in Sources */,

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/AddLinkCoordinator.swift
@@ -55,10 +55,6 @@ private extension AddLinkCoordinator {
                 self?.onFinish?()
             })
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true)
     }
 }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/ClipCoordinator.swift
@@ -39,20 +39,12 @@ private extension ClipCoordinator {
         vc.onClipItemSelected = { [weak self] clipId, clipName in
             self?.showDetailClipVC(id: clipId, name: clipName)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.setRoot(vc, animated: false)
     }
     
     func showEditClipVC(clipList: ClipModel) {
         let vc = viewControllerFactory.makeEditClipVC()
         vc.setupDataBind(clipModel: clipList)
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: false, hideBottomBarWhenPushed: true)
     }
     
@@ -62,10 +54,6 @@ private extension ClipCoordinator {
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -74,10 +62,6 @@ private extension ClipCoordinator {
         vc.setupDataBind(linkURL: linkURL, isRead: isRead, id: id)
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/HomeCoordinator.swift
@@ -48,10 +48,6 @@ private extension HomeCoordinator {
         vc.onAddLinkSelected = { [weak self] in
             self?.startAddLinkCoordinator()
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.setRoot(vc, animated: false)
     }
     
@@ -60,10 +56,6 @@ private extension HomeCoordinator {
         vc.setupDataBind(linkURL: linkURL, isRead: isRead, id: id)
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -74,10 +66,6 @@ private extension HomeCoordinator {
             self?.router.dismiss()  // 로그아웃 완료 Alert dismiss
             self?.onFinish?()
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -86,11 +74,6 @@ private extension HomeCoordinator {
         vc.setupCategory(id: id, name: name)
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/SearchCoordinator.swift
@@ -39,10 +39,6 @@ private extension SearchCoordinator {
         vc.onClipItemSelected = { [weak self] id, name in
             self?.showDetailClipVC(id: id, name: name)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.setRoot(vc, animated: false)
     }
     
@@ -52,10 +48,6 @@ private extension SearchCoordinator {
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -64,10 +56,6 @@ private extension SearchCoordinator {
         vc.setupDataBind(linkURL: linkURL, isRead: isRead, id: id)
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
@@ -33,7 +33,7 @@ final class TabBarCoordinator: BaseCoordinator, CoordinatorFinishOutput {
         guard let tabBarController else { return }
         tabBarController.selectTab(0)
         router.setRoot(tabBarController, animated: false)
-        observeDeleteTokenEvent()
+        observeDeleteTokenEvent()   // 탭바 진입 이후 .refreshTokenExpired Event 계속 감지
     }
 }
 

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift
@@ -33,6 +33,7 @@ final class TabBarCoordinator: BaseCoordinator, CoordinatorFinishOutput {
         guard let tabBarController else { return }
         tabBarController.selectTab(0)
         router.setRoot(tabBarController, animated: false)
+        observeDeleteTokenEvent()
     }
 }
 
@@ -135,5 +136,21 @@ private extension TabBarCoordinator {
             self?.router.popToRoot(animated: false)
         }
         router.push(vc, animated: true)
+    }
+    
+    /// NotificationCenter의 .refreshTokenExpired (리프레시 토큰 만료) 상황을 감지하는 Observer Method
+    /// Event가 발생하면 -> KeyChain에 있는 Token 값을 지우고 -> AppCoordinator에서 TabBarCoordinator onFinish?() 클로저 수행
+    func observeDeleteTokenEvent() {
+        NotificationCenter.default.addObserver(
+            forName: .refreshTokenExpired,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            _ = KeyChainService.deleteTokens(
+                accessKey: Config.accessTokenKey,
+                refreshKey: Config.refreshTokenKey
+            )
+            self?.onFinish?()
+        }
     }
 }

--- a/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
+++ b/TOASTER-iOS/Application/Coordinator/Coordinators/TimerCoordinator.swift
@@ -45,10 +45,6 @@ private extension TimerCoordinator {
         vc.onSettingSelected = { [weak self] in
             self?.showSettingVC()
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.setRoot(vc, animated: false)
     }
     
@@ -60,10 +56,6 @@ private extension TimerCoordinator {
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -72,10 +64,6 @@ private extension TimerCoordinator {
         vc.configureView(forTimerID: id)
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -86,10 +74,6 @@ private extension TimerCoordinator {
         vc.onPopToRoot = { [weak self] in
             self?.router.popToRoot(animated: true)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -98,10 +82,6 @@ private extension TimerCoordinator {
         vc.setupCategory(id: id, name: name)
         vc.onLinkSelected = { [weak self] linkURL, isRead, id in
             self?.showLinkWebVC(linkURL: linkURL, isRead: isRead, id: id)
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
@@ -112,10 +92,6 @@ private extension TimerCoordinator {
         vc.onBack = { [weak self] in
             self?.router.pop(animated: true)
         }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
-            self?.onFinish?()
-        }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)
     }
     
@@ -123,10 +99,6 @@ private extension TimerCoordinator {
         let vc = viewControllerFactory.makeSettingVC()
         vc.onChangeRoot = { [weak self] in
             self?.router.dismiss()
-            self?.onFinish?()
-        }
-        vc.onRootDeleteToken = { [weak self] in
-            _ = KeyChainService.deleteTokens(accessKey: Config.accessTokenKey, refreshKey: Config.refreshTokenKey)
             self?.onFinish?()
         }
         router.push(vc, animated: true, hideBottomBarWhenPushed: true)

--- a/TOASTER-iOS/Global/Consts/Notification.swift
+++ b/TOASTER-iOS/Global/Consts/Notification.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.swift
+//  TOASTER-iOS
+//
+//  Created by mini on 6/4/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let refreshTokenExpired = Notification.Name("refreshTokenExpired")
+}

--- a/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
+++ b/TOASTER-iOS/Present/AddLink/SelectClip/View/SelectClipViewController.swift
@@ -16,7 +16,6 @@ final class SelectClipViewController: UIViewController {
     // MARK: - View Controllable
 
     var onPopToRoot: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -152,8 +151,8 @@ private extension SelectClipViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
+++ b/TOASTER-iOS/Present/Clip/View/ClipViewController.swift
@@ -17,7 +17,6 @@ final class ClipViewController: UIViewController {
     
     var onEditClipSelected: ((ClipModel) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - UI Properties
     
@@ -113,8 +112,8 @@ private extension ClipViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
+++ b/TOASTER-iOS/Present/DetailClip/View/DetailClipViewController.swift
@@ -16,7 +16,6 @@ final class DetailClipViewController: UIViewController {
     // MARK: - View Controllable
     
     var onLinkSelected: ((String, Bool, Int) -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Streams
     
@@ -228,8 +227,8 @@ private extension DetailClipViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
+++ b/TOASTER-iOS/Present/EditClip/View/EditClipViewController.swift
@@ -13,10 +13,6 @@ import Then
 
 final class EditClipViewController: UIViewController {
     
-    // MARK: - View Controllable
-    
-    var onRootDeleteToken: (() -> Void)?
-    
     // MARK: - Data Stream
         
     private let viewModel: EditClipViewModel
@@ -148,8 +144,8 @@ private extension EditClipViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Home/View/HomeViewController.swift
+++ b/TOASTER-iOS/Present/Home/View/HomeViewController.swift
@@ -20,7 +20,6 @@ final class HomeViewController: UIViewController {
     var onSettingSelected: (() -> Void)?
     var onArrowSelected: ((Int, String) -> Void)?
     var onAddLinkSelected: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Stream
     
@@ -262,8 +261,8 @@ private extension HomeViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
+++ b/TOASTER-iOS/Present/LinkWeb/ViewController/LinkWebViewController.swift
@@ -16,7 +16,6 @@ final class LinkWebViewController: UIViewController {
     // MARK: - View Controllable
     
     var onBack: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -123,8 +122,8 @@ private extension LinkWebViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
+++ b/TOASTER-iOS/Present/Remind/View/RemindViewController.swift
@@ -26,7 +26,6 @@ final class RemindViewController: UIViewController {
     var onEditTimerSelected: ((Int) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
     var onSettingSelected: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -222,7 +221,7 @@ private extension RemindViewController {
     }
     
     func unAuthorizedAction() {
-        onRootDeleteToken?()
+        NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
     }
     
     func deleteAction() {

--- a/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/ClipAdd/View/RemindSelectClipViewController.swift
@@ -17,7 +17,6 @@ final class RemindSelectClipViewController: UIViewController {
     
     var onEditTimerSelected: ((RemindClipModel?) -> Void)?
     var onPopToRoot: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
 
     // MARK: - Data Stream
     
@@ -79,8 +78,8 @@ private extension RemindSelectClipViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
+++ b/TOASTER-iOS/Present/RemindAdd/TimerAdd/RemindTimerAddViewController.swift
@@ -20,7 +20,6 @@ final class RemindTimerAddViewController: UIViewController {
     // MARK: - View Controllable
 
     var onPopToRoot: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Streams
 
@@ -196,8 +195,8 @@ private extension RemindTimerAddViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Search/View/SearchViewController.swift
+++ b/TOASTER-iOS/Present/Search/View/SearchViewController.swift
@@ -17,7 +17,6 @@ final class SearchViewController: UIViewController {
     
     var onLinkItemSelected: ((String, Bool, Int) -> Void)?
     var onClipItemSelected: ((Int, String) -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Data Stream
 
@@ -106,8 +105,8 @@ private extension SearchViewController {
             }.store(in: cancelBag)
         
         output.navigateToLogin
-            .sink { [weak self] _ in
-                self?.onRootDeleteToken?()
+            .sink {
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             }.store(in: cancelBag)
     }
     

--- a/TOASTER-iOS/Present/Setting/View/SettingViewController.swift
+++ b/TOASTER-iOS/Present/Setting/View/SettingViewController.swift
@@ -15,7 +15,6 @@ final class SettingViewController: UIViewController {
     // MARK: - View Controllable
 
     var onChangeRoot: (() -> Void)?
-    var onRootDeleteToken: (() -> Void)?
     
     // MARK: - Properties
     
@@ -125,7 +124,7 @@ private extension SettingViewController {
                     self?.userName = responseData.nickname
                 }
             case .unAuthorized, .networkFail:
-                self?.onRootDeleteToken?()
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             default: break
             }
         }
@@ -176,7 +175,7 @@ private extension SettingViewController {
                 self.isToggle = response?.data?.isAllowed
                 self.setupWarningView()
             case .notFound, .networkFail:
-                self.onRootDeleteToken?()
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             default: break
             }
         }
@@ -200,7 +199,7 @@ private extension SettingViewController {
                     }
                 }
             case .unAuthorized, .networkFail:
-                self?.onRootDeleteToken?()
+                NotificationCenter.default.post(name: .refreshTokenExpired, object: nil)
             default:
                 print("default Fail")
             }


### PR DESCRIPTION
## ✨ 해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #252 

## 🛠️ 작업내용
<!-- 작업한 내용을 작성해주세요 ( UI 구현이라면 사진이나 GIF 올려주시면 감사용~ ) -->
- TabBarCoordinator에 Notification을 감지하는 Observer 메서드 `observeDeleteTokenEvent()` 구현했습니다
  - 해당 메서드는 TabBarCoordinator의 하위 Coordinator에서도 계속 감시하며 동작되는데요.
  - 동작은 KeyChain에 저장되어 있는 토큰 값을 지우고 -> TabBarCoordinator의 `onFinish?() `클로저를 호출하는 역할이라 생각하면 됩니다~
 
https://github.com/Link-MIND/TOASTER-iOS/blob/4102bd876f1e875fc47cd28fe3661b5012ec1f41/TOASTER-iOS/Application/Coordinator/Coordinators/TabBarCoordinator.swift#L141-L155

- ViewModel 네트워크 호출 이후 -> VC의 navigateToLogin으로 Output이 방출되었을 때 (토큰 만료 인식) -> VC는 Coordinator와 무관하게 이벤트 (`.refreshTokenExpired`)를 발생시킵니다!

https://github.com/Link-MIND/TOASTER-iOS/blob/4102bd876f1e875fc47cd28fe3661b5012ec1f41/TOASTER-iOS/Present/Home/View/HomeViewController.swift#L263-L266

- 혹은 ViewModel을 사용하지 않고, VC에서 Service 메서드를 바로 사용하는 경우에는 -> 아래와 같이 네트워크 메서드의 결과물로 바로 이벤트를 방출할 수도 있을 겁니다!

https://github.com/Link-MIND/TOASTER-iOS/blob/4102bd876f1e875fc47cd28fe3661b5012ec1f41/TOASTER-iOS/Present/Setting/View/SettingViewController.swift#L119-L131

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
